### PR TITLE
EPIC-868 Added ng-disabled for empty comments and docs

### DIFF
--- a/modules/project-comments/client/views/public-comments/add.html
+++ b/modules/project-comments/client/views/public-comments/add.html
@@ -130,7 +130,7 @@
 	</div>
 	<div class="modal-footer">
 		<button type="button" class="btn btn-default" ng-click="s.cancel()">Cancel</button>
-		<button type="button" class="btn btn-success" ng-click="s.submit()">Submit Comment</button>
+		<button type="button" class="btn btn-success" ng-click="s.submit()" ng-disabled="!s.comment.comment && s.fileList.length === 0">Submit Comment</button>
 	</div>
 </form><!-- / COMMENT FORM - STEP 2 -->
 


### PR DESCRIPTION
I changed the code for EPIC-868 issue by not allowing users to click submit button in add comment modal if the comment is empty and has zero docs added.