### PR TITLE
EPIC-964 Fixing issue with long names wrapping in the PCP list

### DIFF
--- a/modules/project-comments/client/scss/project-comments.scss
+++ b/modules/project-comments/client/scss/project-comments.scss
@@ -505,6 +505,8 @@ $pcp-comment-icon-color: #ccc;
     .comment-table { 
         .location-col {
             width: 12rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .pillar-col {


### PR DESCRIPTION
Long single-string names will now truncate with the ellipsis if they run past the column width.