### PR TITLE
EPIC-1032 double spinner fixed

### DIFF
--- a/modules/search/client/views/partials/search-widget.html
+++ b/modules/search/client/views/partials/search-widget.html
@@ -9,6 +9,6 @@
 		</button>
 	</form>
 </div>
-<div class="spinner-container" ng-show="vm.busy" ng-animate>
+<div class="spinner-container" ng-if="vm.busy" ng-animate>
 	<div class="spinner-new rotating"></div>
 </div>


### PR DESCRIPTION
Use ng-if rather than ng-show. With ng-show the spinner appears until the controller is compiled because ng-show defaults to show until it can resolve the expression. ng-if defaults to hide until it can resolve the expression.