### PR TITLE
MEM- Pull EPIC changes that affect Doc Manager

### DIFF
--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -291,11 +291,25 @@ angular.module('documents')
 
 					self.currentNode = theNode; // this is the current Directory in the bread crumb basically...
 					self.folderURL = window.location.protocol + "//" + window.location.host + "/p/" + $scope.project.code + "/docs?folder=" + self.currentNode.model.id;
-					self.currentPath = theNode.getPath() || [];
+					//self.currentPath = theNode.getPath() || [];
 					self.unsortedFiles = [];
 					self.unsortedDirs = [];
 					self.currentFiles = [];
 					self.currentDirs = [];
+
+					var pathArray = theNode.getPath()
+					_.each(pathArray, function (elem) {
+						if (elem.model.id > 1) { //bail the root node cus we don't need to attatch the folderObj to it
+							if (!elem.model.hasOwnProperty('folderObj')) { //trying to reduce the amount of API calls only by checking if node model does not have folderObj
+								FolderModel.lookup($scope.project._id, elem.model.id)
+								.then(function (folder) {
+									elem.model.folderObj = folder;
+								})
+							}
+						}
+					})
+					self.currentPath = pathArray || [];
+
 
 					//$log.debug('currentNode (' + self.currentNode.model.name + ') get documents...');
 					DocumentMgrService.getDirectoryDocuments($scope.project, self.currentNode.model.id)

--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -89,6 +89,7 @@ angular.module('documents')
 						//self.infoPanel.open = false;
 						self.infoPanel.type = 'None';
 						self.infoPanel.data = undefined;
+						self.infoPanel.link = undefined;
 					},
 					setData: function() {
 						self.infoPanel.reset();
@@ -98,6 +99,7 @@ angular.module('documents')
 								self.infoPanel.type = 'File';
 								var file = _.find(self.currentFiles, function(o) { return o._id.toString() === self.lastChecked.fileId; });
 								self.infoPanel.data = file ? file : undefined;
+								self.infoPanel.link =  window.location.protocol + '//' + window.location.host + '/api/document/'+ file._id+'/fetch';
 							} else if (self.lastChecked.directoryID) {
 								self.infoPanel.type = 'Directory';
 								var node =_.find(self.currentDirs, function(o) { return o.model.id === self.lastChecked.directoryID; });

--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -297,17 +297,17 @@ angular.module('documents')
 					self.currentFiles = [];
 					self.currentDirs = [];
 
-					var pathArray = theNode.getPath()
+					var pathArray = theNode.getPath();
 					_.each(pathArray, function (elem) {
 						if (elem.model.id > 1) { //bail the root node cus we don't need to attatch the folderObj to it
 							if (!elem.model.hasOwnProperty('folderObj')) { //trying to reduce the amount of API calls only by checking if node model does not have folderObj
 								FolderModel.lookup($scope.project._id, elem.model.id)
 								.then(function (folder) {
 									elem.model.folderObj = folder;
-								})
+								});
 							}
 						}
-					})
+					});
 					self.currentPath = pathArray || [];
 
 

--- a/modules/documents/client/directives/documents.manager.link.directive.js
+++ b/modules/documents/client/directives/documents.manager.link.directive.js
@@ -15,12 +15,19 @@ angular.module('documents')
 				self.busy = true;
 
 				$scope.authentication = Authentication;
-				$scope.project.directoryStructure = $scope.project.directoryStructure || {
+
+				ProjectModel.getProjectDirectory($scope.project)
+				.then( function (dir) {
+					$scope.project.directoryStructure = dir || {
 						id: 1,
 						lastId: 1,
 						name: 'ROOT',
 						published: true
 					};
+					self.rootNode = tree.parse($scope.project.directoryStructure);
+					self.selectNode(self.rootNode);
+					$scope.$apply();
+				});
 
 				// default sort is by name ascending...
 				self.sorting = {
@@ -28,7 +35,7 @@ angular.module('documents')
 					ascending: true
 				};
 
-				self.rootNode = tree.parse($scope.project.directoryStructure);
+			//	self.rootNode = tree.parse($scope.project.directoryStructure);
 				self.selectedNode = undefined;
 				self.currentNode = undefined;
 				self.currentPath = undefined;
@@ -202,8 +209,6 @@ angular.module('documents')
 							}
 						);
 				};
-
-				self.selectNode(self.rootNode.model.id);
 
 			},
 			controllerAs: 'documentMgr'

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -467,6 +467,10 @@
 									<span class="name">Uploaded Date:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.dateUploaded | date : format : timezone }}</span>
 								</li>
+								<li ng-if="documentMgr.infoPanel.link">
+									<span class="name">Link:</span>
+									<span class="value">{{ documentMgr.infoPanel.link }}</span>
+								</li>
 								<li>
 									<span class="name">Size:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.internalSize | bytes:2 }}</span>

--- a/modules/projects/server/controllers/project.controller.js
+++ b/modules/projects/server/controllers/project.controller.js
@@ -895,7 +895,7 @@ module.exports = DBModel.extend ({
 					// console.log("dir:", dir);
 					return f.oneIgnoreAccess({_id: dir._id})
 					.then(function (d) {
-						d.parentId = newParentId;
+						d.parentID = newParentId;
 						_dir = d;
 						return self.findById(projectId);
 					});


### PR DESCRIPTION
Here are the git log messages for the commits pulled over, listed in the order they were applied:
[2017-04-23] [0d3fc00] Fixed folders display name not showing in folders navigation pane  {{Ushanth Loganathan}} 
[2017-04-23] [2858406] Minor indenting fixes  {{Ushanth Loganathan}} 
cherry picked the essential line of code from:
[2017-05-17] [f135cb1] EPIC-1010 - Fix link documents to VC  {{Ushanth Loganathan}} 
[2017-05-26] [400a143] EPIC-1025 - Fixed issue with move folders displayname  {{Ushanth Loganathan}} 
[2017-05-29] [c5bbb25] EPIC-1025 - Added FolderObj to move modal selectnode function  {{Ushanth Loganathan}} 
[2017-06-05] [0123efd] EPIC-1060 add copiable link to the info panel for files  {{Bryan Gilbert}}  (bgil-EPIC1060)