### PR TITLE
EPIC-1093 Document link layout fixed plus add Copy Link button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,11 +29,14 @@
     "angular-resizable": "latest",
     "pdfjs-dist": "latest",
     "ng-pdfviewer": "^0.2.1",
-    "tree-model-bower" : "git://github.com/BCDevOps/tree-model-bower",
-    "angular-smart-table": "2.1.8"
+    "tree-model-bower": "git://github.com/BCDevOps/tree-model-bower",
+    "angular-smart-table": "2.1.8",
+    "ngclipboard": "^1.1.1",
+    "clipboard": "^1.7.1"
   },
   "resolutions": {
     "angular": "^1.5.9",
-    "lodash": "4.5.1"
+    "lodash": "4.5.1",
+    "clipboard": "^1.7.1"
   }
 }

--- a/config/assets/default.js
+++ b/config/assets/default.js
@@ -49,7 +49,9 @@ module.exports = {
 				'public/lib/ng-pdfviewer/compatibility.js',
 				'public/readable-range.js',
 				'public/lib/tree-model-bower/dist/TreeModel-min.js',
-				'public/lib/angular-smart-table/dist/smart-table.js'
+				'public/lib/angular-smart-table/dist/smart-table.js',
+				'public/lib/clipboard/dist/clipboard.min.js',
+				'public/lib/ngclipboard/dist/ngclipboard.min.js'
 			],
 			tests: ['public/lib/angular-mocks/angular-mocks.js']
 		},

--- a/modules/core/client/app/config.js
+++ b/modules/core/client/app/config.js
@@ -23,7 +23,8 @@ var ApplicationConfiguration = (function () {
     'duScroll',
     'ngPDFViewer',
     'ngCookies',
-		'smart-table'
+		'smart-table',
+		'ngclipboard'
   ];
 
 

--- a/modules/core/client/scss/global/helpers.scss
+++ b/modules/core/client/scss/global/helpers.scss
@@ -66,3 +66,7 @@
 		@include flex(0 0 auto);
 	}
 }
+
+.break-all {
+	word-break: break-all;
+}

--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -17,6 +17,16 @@ angular.module('documents')
 				self.requestOpenDir = null;
 				self.requestOpenFileID = null;
 
+				$scope.copyClipboardSuccess = function(e) {
+					var txt = e.trigger.getAttribute('data-doc-name');
+					AlertService.success('Link copied for ' + txt);
+					e.clearSelection();
+				};
+
+				$scope.copyClipboardError = function(e) {
+					AlertService.error('Copy link failed.');
+				};
+
 				if ($scope.file) {
 					self.requestOpenFileID = $scope.file; // objectId
 				}
@@ -281,6 +291,8 @@ angular.module('documents')
 								if (_.isEmpty(f.displayName)) {
 									f.displayName = f.documentFileName || f.internalOriginalName;
 								}
+								f.link =  window.location.protocol + '//' + window.location.host + '/api/document/'+ f._id+'/fetch';
+
 								if (_.isEmpty(f.dateUploaded) && !_.isEmpty(f.oldData)) {
 									var od = JSON.parse(f.oldData);
 									//console.log(od);

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -286,6 +286,17 @@
 													<span class="glyphicon glyphicon-edit"></span>
 												</button>
 											</li>
+											<li>
+												<button class="btn icon-btn" title="Copy Link to Clipboard"
+													ngclipboard
+													data-clipboard-text="{{ doc.link }}"
+													data-doc-name="{{ doc.displayName }}"
+													ngclipboard-success="copyClipboardSuccess(e);"
+													ngclipboard-error="copyClipboardError(e);"
+													>
+													<span class="glyphicon glyphicon-copy"></span>
+												</button>
+											</li>
 											<li ng-if="doc.userCan.publish && !doc.isPublished">
 												<button class="btn icon-btn" title="Publish File" ng-click="$event.stopPropagation();"
 														x-confirm-dialog
@@ -368,6 +379,15 @@
 						<h2 title="{{documentMgr.infoPanel.data.displayName | removeExtension}}">{{documentMgr.infoPanel.data.displayName | removeExtension }}</h2>
 					</div>
 					<div class="title-panel-btns">
+						<button class="btn btn-sm btn-default" title="Copy Link to Clipboard"
+										ngclipboard
+										data-doc-name="documentMgr.infoPanel.data.displayName"
+										data-clipboard-text="{{ documentMgr.infoPanel.data.link }}"
+										ngclipboard-success="copyClipboardSuccess(e);"
+										ngclipboard-error="copyClipboardError(e);"
+						>
+							<span class="glyphicon glyphicon-copy"></span>
+						</button>
 						<a ng-if="documentMgr.infoPanel.data.userCan.read"
 						   class="btn btn-sm btn-default"
 						   href="/api/document/{{ documentMgr.infoPanel.data._id }}/fetch"
@@ -459,9 +479,9 @@
 									<span class="name">Uploaded Date:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.dateUploaded | date : format : timezone }}</span>
 								</li>
-								<li ng-if="documentMgr.infoPanel.link">
+								<li>
 									<span class="name">Link:</span>
-									<span class="value">{{ documentMgr.infoPanel.link }}</span>
+									<span class="value break-all"><a href="{{documentMgr.infoPanel.data.link}}" target="_blank">{{ documentMgr.infoPanel.data.link }}</a></span>
 								</li>
 								<li>
 									<span class="name">Size:</span>

--- a/modules/search/client/directives/search.directive.js
+++ b/modules/search/client/directives/search.directive.js
@@ -34,9 +34,9 @@ function directiveSearchInfoPanel(Authentication, CodeLists) {
 	};
 }
 
-searchResultsDocumentDirective.$inject = ['_', 'SearchService', 'SearchResultsService', '$rootScope', 'Authentication',  'ProjectModel'];
+searchResultsDocumentDirective.$inject = ['_', 'AlertService', 'SearchService', 'SearchResultsService', '$rootScope', 'Authentication',  'ProjectModel'];
 /* @ngInject */
-function searchResultsDocumentDirective(_, SearchService, SearchResultsService, $rootScope, Authentication, ProjectModel) {
+function searchResultsDocumentDirective(_, AlertService, SearchService, SearchResultsService, $rootScope, Authentication, ProjectModel) {
 	return {
 		restrict: 'E',
 		scope: {
@@ -64,6 +64,15 @@ function searchResultsDocumentDirective(_, SearchService, SearchResultsService, 
 			self.sortBy = sortBy;
 			self.toggleInfoPanel = toggleInfoPanel;
 
+			self.copyClipboardSuccess = function(e) {
+				var txt = e.trigger.getAttribute('data-doc-name');
+				AlertService.success('Link copied for ' + txt);
+				e.clearSelection();
+			};
+
+			self.copyClipboardError = function(e) {
+				AlertService.error('Copy link failed.');
+			};
 			// init
 			reload($scope.results);
 			// end of configuration
@@ -89,6 +98,7 @@ function searchResultsDocumentDirective(_, SearchService, SearchResultsService, 
 					var displayItem = {};
 					displayItem.isFile = true;
 					displayItem.id = item._id;
+					displayItem.link = window.location.protocol + "//" + window.location.host + "/api/document/" + displayItem.id  + "/fetch";
 					displayItem.path = SearchService.composeFilePath(item.directoryID, item.displayName);
 					displayItem.displayName = item.displayName;
 					displayItem.description = item.description;

--- a/modules/search/client/views/search-results-documents.html
+++ b/modules/search/client/views/search-results-documents.html
@@ -65,6 +65,17 @@
 											</button>
 											<ul class="dropdown-menu pull-right">
 												<li>
+													<button class="btn icon-btn" title="Copy Link to Clipboard"
+																	ngclipboard
+																	data-clipboard-text="{{ item.link }}"
+																	data-doc-name="{{ item.displayName }}"
+																	ngclipboard-success="vm.copyClipboardSuccess(e);"
+																	ngclipboard-error="vm.copyClipboardError(e);"
+													>
+														<span class="glyphicon glyphicon-copy"></span>
+													</button>
+												</li>
+												<li>
 													<button class="btn icon-btn" title="Properties" ng-click="vm.toggleInfoPanel();$event.stopPropagation();">
 														<span class="glyphicon glyphicon-info-sign"></span>
 													</button>


### PR DESCRIPTION
Copy button appears on Doc Manager and Search Results.
This PR adds clipboard.js and ngclipboard.js to the bower file. Dev's need to run bower update to get the copy to clipboard to function.