### PR TITLE
EPIC-1123 small fixes

### DIFF
--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -613,7 +613,7 @@ angular.module('documents')
 								});
 								msg = 'This action cannot be completed as the following documents are published: ' + theDocs + '.  Please unpublish each document and attempt your action again.';
 							} else {
-								msg = "Could complete operation.";
+								msg = "Couldn't complete operation.";
 							}
 							self.busy = false;
 							AlertService.error(msg);

--- a/modules/documents/client/styles/file-browser.scss
+++ b/modules/documents/client/styles/file-browser.scss
@@ -108,10 +108,15 @@ a.icon-btn {
 
     span.name {
         width: 15rem;
+        min-width: 15rem;
     }
 
     span.value {
         @include flex(1 1 auto);
+
+        ul {
+            padding-left: 0;
+        }
     }
 }
 
@@ -1006,6 +1011,16 @@ $fb-upload-target-border: 2px dashed #BBB;
             font-style: italic;
             color: #666;
         }
+    }
+}
+
+.file-browser {
+    .doc-keywords-list ul {
+        padding-left: 0;
+    }
+    .document-description {
+        overflow-y: hidden;
+        overflow-wrap: break-word;
     }
 }
 

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -170,7 +170,7 @@
 										</button>
 										<ul class="dropdown-menu pull-right">
 											<li ng-if="project.userCan.manageFolders">
-												<button class="btn icon-btn" title="Edit FFF" ng-click="$event.stopPropagation();"
+												<button class="btn icon-btn" title="Edit Folder Details" ng-click="$event.stopPropagation();"
 														x-document-mgr-edit
 														x-project="project"
 														x-doc="doc"
@@ -464,7 +464,7 @@
 						<h2>File Details</h2>
 						<section ng-if="documentMgr.infoPanel.data.description">
 							<h3>Description</h3>
-							<div class="value">{{ documentMgr.infoPanel.data.description }}</div>
+							<div class="value document-description">{{ documentMgr.infoPanel.data.description }}</div>
 						</section>
 						<section>
 							<h3>Properties</h3>


### PR DESCRIPTION
During the migration of EPIC fixes to MEM I found a few small issues that MEM had fixed that should be on EPIC.
1. an error message said "Could ..." when it really meant "Couldn't ..." the error message only happens in unusual, difficult to reproduce, situations.
2. formatting on the Doc Manager Info Panel. 
a. aligning the labels and data
b. word wrapping long descriptions (even with content that lacks natural word breaks)
3. The tool tip on the Edit Folder icon on the ellipse menu on a folder row