### PR TITLE
EPIC-1022 - Fix Doc Manager folder renaming issue

### DIFF
--- a/modules/documents/client/directives/documents.manager.edit.directive.js
+++ b/modules/documents/client/directives/documents.manager.edit.directive.js
@@ -133,9 +133,17 @@ angular.module('documents')
 												// somewhere here we need to tell document manager to refresh it's document...
 												if (scope.onUpdate) {
 													scope.onUpdate(result);
+													DocumentMgrService.renameDirectory($scope.project, scope.doc, $scope.doc.displayName)
+														.then(
+														function (result) {
+															self.busy = false;
+															$modalInstance.close(result.data);
+														},
+														function (err) {
+															AlertService.error("Could not rename folder");
+														}
+														); 
 												}
-												self.busy = false;
-												$modalInstance.close(result);
 											} else {
 												self.busy = false;
 												AlertService.error("Sorry, folder already exists.  Please choose another name.");

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -530,7 +530,7 @@
 						<button class="btn btn-default close" type="button" ng-click="documentMgr.infoPanel.close()">
 							<span aria-hidden="true">&times;</span>
 						</button>
-						<h2 title="{{documentMgr.infoPanel.data.name}}">{{documentMgr.infoPanel.data.name}}</h2>
+						<h2 title="{{documentMgr.infoPanel.data.name}}">{{documentMgr.infoPanel.data.folderObj.displayName}}</h2>
 					</div>
 				</div>
 				<div class="scroll-container">


### PR DESCRIPTION
The folder is not getting renamed in the project.directory structure and that is the reason I had to use the DocumentMangerService to rename it in directoryStructure.