### PR TITLE
Fixing column sizing issue in the PCP related docs interface

### DIFF
--- a/modules/project-comments/client/views/partials/period-documents-list.html
+++ b/modules/project-comments/client/views/partials/period-documents-list.html
@@ -14,7 +14,7 @@
                     <span>Size</span>
                     <span class="sort-icon" ng-show="ctrl.sorting.column === 'size'"></span>
                 </div>
-                <div class="col size-col sortable last-col" ng-if="ctrl.authentication.user" ng-class="{'descending': !ctrl.sorting.ascending}" ng-click="ctrl.sortBy('pub')">
+                <div class="col status-col sortable last-col" ng-if="ctrl.authentication.user" ng-class="{'descending': !ctrl.sorting.ascending}" ng-click="ctrl.sortBy('pub')">
                     <span>Status</span>
                     <span class="sort-icon" ng-show="ctrl.sorting.column === 'pub'"></span>
                 </div>


### PR DESCRIPTION
Updating to the correct column naming convention in the PCP documents interface for the 'Status' column