### PR TITLE
EPIC-1157- fix PCP related docs layout issues

### DIFF
--- a/modules/project-comments/client/scss/project-comments.scss
+++ b/modules/project-comments/client/scss/project-comments.scss
@@ -736,8 +736,18 @@ $pcp-comment-icon-color: #ccc;
                 background-color: #ddd;
             }
         }
+
     }
 }
+/*
+Set the width on the related documents list, just for PCP, to handle very long file names.
+Without this the layout is busted.
+Don't want to apply this to all uses of fb-col-group.
+ */
+.pcp-linked-documents .fb-col-group {
+    width: 100%
+}
+
 
 .public-comment-modal {
     section {

--- a/modules/project-comments/client/views/partials/period-documents-list.html
+++ b/modules/project-comments/client/views/partials/period-documents-list.html
@@ -33,11 +33,14 @@
                             <span class="fb-file glyphicon glyphicon-file" ng-if="!['png','jpg','jpeg'].includes(doc.internalExt)"></span>
                             <span class="fb-img glyphicon glyphicon-picture" ng-if="['png','jpg','jpeg'].includes(doc.internalExt)"></span>
                         </span>
-                        <a href="/api/document/{{ doc._id }}/fetch" target="_self">{{doc.displayName}}</a>
+                        <a href="/api/document/{{ doc._id }}/fetch" title="{{doc.displayName}}" target="_self">{{doc.displayName}}</a>
                     </span>
                     <span class="col type-col">{{ doc.internalExt}}</span>
                     <span class="col size-col">{{ doc.internalSize | bytes:2 }}</span>
-                    <span class="col status-col" ng-if="ctrl.authentication.user" ><span ng-if="doc.isPublished" title="Published"><span class="glyphicon glyphicon-ok-circle"></span></span></span>
+                    <span class="col status-col" ng-if="ctrl.authentication.user" >
+                      <span class="label label-success" ng-if="doc.isPublished" title="Published">Published</span>
+                      <span class="label label-unpublished" ng-if="!doc.isPublished" title="Unpublished">Unpublished</span>
+                    </span>
                     <span class="row-actions visible">
                         <div class="btn-group">
                             <button class="btn icon-btn dropdown-toggle" type="button" ng-click="$event.originalEvent.dropdown = true" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
In the Ajax PCP the related documents layout is broken. Some rows lack the ellipse needed to download the file.
As well, the long file names are not accessible to the end user.
As well, for authenticated users, the "publish" flag is using the old circle icon. Change this to match the rest of the site.