### PR TITLE
EPIC-1113 - Setting default 'Active' State for activities to false

### DIFF
--- a/modules/recent-activity/server/models/recent-activity.model.js
+++ b/modules/recent-activity/server/models/recent-activity.model.js
@@ -10,7 +10,7 @@ module.exports = require ('../../../core/server/controllers/core.schema.controll
 	headline : { type: String, default:'' },
 	content  : { type: String, default:'' },
 	project  : { type: 'ObjectId', ref:'Project', index:true, default:null },
-	active   : { type: Boolean, default: true },
+	active   : { type: Boolean, default: false },
 	priority : { type: Number, default: 2, index:true },
 	type     : { type: String, default:'' }, // news | public comment period
     contentUrl  : {type: String, default:''},


### PR DESCRIPTION
Setting the default active state to false for new activities and updates. Requested specifically to address the staging of new items without concern that the initial 'save' will immediately make the new item visible.