### PR TITLE
EPIC-1073 Fix missing permissions

### DIFF
--- a/scripts/fixDocPerms/etlDocsMissingPerms.js
+++ b/scripts/fixDocPerms/etlDocsMissingPerms.js
@@ -1,0 +1,152 @@
+'use strict';
+var MongoClient    = require('mongodb').MongoClient;
+var Promise        = require('promise');
+var _              = require('lodash');
+var etl            = require('./etlHelper');
+
+var argv           = require('minimist')(process.argv.slice(2));
+argv.scriptName    = process.argv[1].split('/').pop();
+
+etl.init(argv);
+
+var connectionString = etl.getConnectString();
+var fixedDocIds = [];
+var processingCollectionName = 'workingTable';
+
+function prepare() {
+	return new Promise(function(resolve, reject) {
+		MongoClient.connect(connectionString, function(err, db) {
+			if (err) {
+				return reject(err);
+			}
+			var collection = db.collection('documents');
+			collection.aggregate( [ { $project: {displayName:1, project:1, processed: { $literal: false }}},{ $out: processingCollectionName } ],
+				function(err, result) {
+					db.close();
+					if (err) {
+						return reject(err);
+					} else {
+						console.log('Prepared temporary working collection: ', processingCollectionName);
+						return resolve(result);
+					}
+				});
+		});
+	});
+}
+function cleanUp() {
+	return new Promise(function(resolve, reject) {
+		MongoClient.connect(connectionString, function(err, db) {
+			var collection = db.collection(processingCollectionName);
+			collection.drop(
+				function(err, result) {
+					db.close();
+					if (err) {
+						reject(err);
+					} else {
+						console.log("Temporary working collection '" + processingCollectionName + "' has been removed");
+						resolve(result);
+					}
+				});
+		});
+	});
+}
+
+var countingCallback = function (db, processingCollection, processingElement) {
+	return new Promise(function (resolve, reject) {
+		var permissions = db.collection('_permissions');
+		var id = processingElement._id.toString();
+		permissions.find({resource: id}).count()
+		.then( function (cnt) {
+			processingElement.processed = true;
+			processingElement.permissions = cnt;
+			processingCollection.update({_id: processingElement._id}, {$set: processingElement},
+			function (err, result) {
+				if (err)
+					return reject(err);
+				return resolve(processingElement);
+			});
+		})
+	});
+};
+
+function fixingCallback(db, processingCollection, processingElement) {
+	return new Promise(function (resolve, reject) {
+		var permissions = db.collection('_permissions');
+		var id = processingElement._id.toString();
+		var perm = composePerm(id);
+		// console.log("Insert default permissions for document id", id);
+		return permissions.insertMany(perm, function (err, result) {
+			if (err) {
+				console.log("Error ", err);
+				return reject(err);
+			}
+			fixedDocIds.push(id);
+			return resolve(resolve);
+		});
+	});
+}
+
+
+var defaultPerms = {
+		'read'      : [
+			'assessment-admin'
+			, 'project-intake'
+			, 'assessment-lead'
+			, 'assessment-team'
+			, 'assistant-dm'
+			, 'project-epd'
+			, 'assistant-dmo'
+			, 'associate-dm'
+			, 'associate-dmo'
+			, 'compliance-lead'
+			, 'compliance-officer'
+			, 'project-system-admin'
+		],
+		'write'     : ['assessment-admin', 'project-system-admin'],
+		'delete'    : ['assessment-admin', 'project-system-admin'],
+		'publish'   : ['assessment-admin', 'project-system-admin'],
+		'unPublish' : ['assessment-admin', 'project-system-admin']
+	};
+
+function composePerm(resourceId) {
+	var results = [];
+	_.forEach(defaultPerms, function (values, key) {
+		_.forEach(values, function (r) {
+			var np = {resource: resourceId, permission: key, role: r, "__v" : 0};
+			results.push(np);
+		});
+	});
+	return results;
+}
+
+console.log("Starting ETL.\n       ConnectionString:",connectionString);
+prepare()
+.then( function() {
+	var query1 = {processed: false };
+	return etl.runETL(connectionString, processingCollectionName, query1, countingCallback);
+})
+.then(function (results) {
+	var query2 = {permissions: { $eq: 0}};
+	return etl.runOnce(connectionString, processingCollectionName, query2, fixingCallback);
+})
+.then (function(results) {
+	console.log("Here is a list of all documents that have had their permissions fixed: ");
+	console.log('[');
+	_.forEach(fixedDocIds, function(id) {
+		console.log("'"+ id + "',");
+	});
+	console.log("]");
+})
+.then( function() {
+	return cleanUp();
+})
+.then( function() {
+	console.log("Ending ETL.");
+	process.exit();
+})
+.catch( function (err) {
+	console.log("Error: ", err);
+	process.exit(1);
+})
+;
+

--- a/scripts/fixDocPerms/etlHelper.js
+++ b/scripts/fixDocPerms/etlHelper.js
@@ -1,0 +1,274 @@
+/**
+ * ETL helper.
+ * Usage
+ * var etl = require('./etlHelper');
+ * var connectionString = etl.composeConnectString(host, port, db, username, password, authSource);
+ * etl.runUpdate(connectionString, collectionName, query, updateDocCallback);
+ */
+'use strict';
+var MongoClient = require('mongodb').MongoClient;
+var LIMIT = 2000;
+
+var defaultDb      = ''; // make db required argument 'esm-dev';
+var defaultPort    = '27017';
+var userName, password, host, port, db, authSource;
+
+function usage(argv) {
+	var msg = [];
+	msg.push('node ' + argv.scriptName + ' <options>');
+	msg.push('  -d database (required)');
+	msg.push('  -u user -p password (optional)' );
+	msg.push('  -h host (default localhost');
+	msg.push('  -n portNumber (default '+ defaultPort);
+	console.log(msg.join('\n'));
+}
+function init(argv) {
+	if (!argv.d) {
+		usage(argv);
+		process.exit(1);
+	}
+	userName       = argv.u ? argv.u : "";
+	password       = argv.p ? argv.p : "";
+	host           = argv.h ? argv.h : 'localhost';
+	port           = argv.n ? argv.n : defaultPort;
+	db             = argv.d ? argv.d : defaultDb;
+}
+
+// Is this needed for invalid certs?
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+
+module.exports = {
+	init: init,
+	getConnectString: getConnectString,
+	runUpdate: runUpdate,
+	runExtract: runExtract,
+	runETL: runETL,
+	runOnce: runOnce,
+	pingTest: pingTest
+};
+
+function getConnectString() {
+	var connectionString = composeConnectString(host, port, db, userName, password, authSource);
+	return connectionString;
+}
+
+function runOnce(connectionString, collectionName, query, callback) {
+	var qStr = JSON.stringify(query);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			var collection = db.collection(collectionName);
+			// first check there are records because cursor.forEach() hangs on empty result sets.
+			collection.find(query).count()
+			.then(function (cnt) {
+				if (cnt === 0) {
+					console.log("No results for query ", qStr);
+					db.close();
+					return resolve(0);
+				} else {
+					//console.log("ETL batch ", qStr);
+					var pending = 0;
+					var cursor = collection.find(query).limit(LIMIT).forEach(function (document) {
+						pending++;
+						callback(db, collection, document)
+						.then(function (result) {
+							pending--;
+							if (pending === 0) {
+								// exit for each .. we're done .. return count of remaining records
+								console.log("Done ETL batch   ", qStr, " remaining cnt: ", cnt);
+								db.close();
+								return resolve(cnt);
+							}
+						})
+						.catch (function(err) {
+							console.log("ETL Helper runonce error: ", err);
+							db.close();
+							return reject(err);
+						})
+						;
+					});
+				}
+			});
+		});
+	});
+}
+
+/*
+ Run batches of size LIMIT until there are no more records that match the query.
+ */
+function runETL(connectionString, collectionName, query, callback) {
+	return batchETL(connectionString, collectionName, query, callback)
+	.then(function (cnt) {
+		if (cnt > 0) {
+			return runETL.bind(null)(connectionString, collectionName, query, callback);
+		} else {
+			console.log("Done ETL for query ", JSON.stringify(query));
+		}
+	})
+}
+
+function batchETL(connectionString, collectionName, query, callback) {
+	var qStr = JSON.stringify(query);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			var collection = db.collection(collectionName);
+			// first check there are records because cursor.forEach() hangs on empty result sets.
+			collection.find(query).count()
+			.then(function (cnt) {
+				if (cnt === 0) {
+					console.log("No results for query ", qStr);
+					db.close();
+					return resolve(0);
+				} else {
+					//console.log("ETL batch ", qStr);
+					var pending = 0;
+					var cursor = collection.find(query).limit(LIMIT).forEach(function (document) {
+						pending++;
+						callback(db, collection, document)
+						.then(function (result) {
+							pending--;
+							if (pending === 0) {
+								// exit for each .. we're done .. return count of remaining records
+								collection.find(query).count()
+								.then(function (cnt) {
+									console.log("Done ETL batch   ", qStr, " remaining cnt: ", cnt);
+									db.close();
+									return resolve(cnt);
+								})
+							}
+						});
+					});
+				}
+			});
+		});
+	});
+}
+
+/*
+ Run the update on a set of documents. Returns (promise) the count of remaining records needing update.
+ */
+function runExtract(connectionString, collectionName, query, fields) {
+	var qStr = JSON.stringify(query);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			var collection = db.collection(collectionName);
+			collection.find(query, fields).toArray( function(err,results) {
+				db.close();
+				return resolve(results);
+			})
+		});
+	});
+}
+
+function composeConnectString(host, port, db, userName, password, authSource) {
+	var connectionString = "mongodb://";
+	if (userName.length>0) {
+		connectionString += userName + ":" + password + "@";
+	}
+	connectionString += host + ":" + port + "/" + db;
+	if (authSource) {
+		connectionString += "?authSource=" + authSource;
+	}
+	return connectionString;
+}
+
+function pingTest(connectionString, collectionName, query) {
+	var qStr = JSON.stringify(query);
+	console.log("Try connection with ", connectionString);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			console.log("connected ... next try query");
+			var collection = db.collection(collectionName);
+			// first check there are records because cursor.forEach() hangs on empty result sets.
+			collection.find(query).count()
+			.then(function (cnt) {
+					console.log("Query resulted found " + cnt + " records");
+					db.close();
+					return resolve(0);
+			});
+		});
+	});
+}
+
+/*
+ Run batches of size LIMIT until there are no more records that match the query.
+ */
+function runUpdate(connectionString, collectionName, query, updateDocCallback) {
+	return batchUpdate(connectionString, collectionName, query, updateDocCallback)
+	.then(function (cnt) {
+		if (cnt > 0) {
+			runUpdate.bind(null)(connectionString, collectionName, query, updateDocCallback);
+		} else {
+			console.log("Done ETL for query ", JSON.stringify(query));
+		}
+	})
+}
+
+/*
+ Run the update on a set of documents. Returns (promise) the count of remaining records needing update.
+ */
+function batchUpdate(connectionString, collectionName, query, updateCallback) {
+	var qStr = JSON.stringify(query);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			var collection = db.collection(collectionName);
+			// first check there are records because cursor.forEach() hangs on empty result sets.
+			collection.find(query).count()
+			.then(function (cnt) {
+				if (cnt === 0) {
+					console.log("No results for query ", qStr);
+					db.close();
+					return resolve(0);
+				} else {
+					console.log("Update batch ", qStr);
+					var pending = 0;
+					var cursor = collection.find(query).limit(LIMIT).forEach(function (document) {
+						pending++;
+						updateCallback(document)
+						.then(function (d) {
+							collection.update({_id: d._id}, {$set: d}, function (err, result) {
+								if (err) {
+									db.close();
+									return reject(err);
+								}
+								pending--;
+								if (pending === 0) {
+									// exit for each .. we're done .. return count of remaining records
+									collection.find(query).count()
+									.then(function (cnt) {
+										console.log("Done batch   ", qStr, " remaining cnt: ", cnt);
+										db.close();
+										return resolve(cnt);
+									})
+								}
+							});
+						})
+					});
+				}
+			});
+		});
+	});
+}
+
+process.on('unhandledRejection', function (error, promise) {
+	console.error("UNHANDLED REJECTION", error, error.stack);
+	process.exit(1);
+});
+process.on('uncaughtException', function (error) {
+	console.error("UNCAUGHT EXCEPTION", error, error.stack);
+	process.exit(1);
+});

--- a/scripts/fixDocPerms/etlPing.js
+++ b/scripts/fixDocPerms/etlPing.js
@@ -1,0 +1,25 @@
+/**
+ * Script to test db connection by executing a query.
+ */
+'use strict';
+var etl            = require('./etlHelper');
+
+var argv           = require('minimist')(process.argv.slice(2));
+argv.scriptName    = process.argv[1].split('/').pop();
+
+etl.init(argv);
+
+var connectionString = etl.getConnectString();
+var query1 = { $or: [ {displayName: {$eq: null}}, {displayName: {$eq: ''}} ] };
+console.log("Starting Ping.");
+etl.pingTest(connectionString,'documents', query1)
+.then( function() {
+	console.log("Ending Ping Test.");
+	process.exit();
+})
+.catch( function (err) {
+	console.log("Error: ", err);
+	process.exit(1);
+})
+;
+

--- a/scripts/fixDocPerms/setup.sh
+++ b/scripts/fixDocPerms/setup.sh
@@ -1,0 +1,1 @@
+npm install request lodash mongodb promise minimist


### PR DESCRIPTION
ETL script to add permissions to documents that have none.
To run first invoke setup in the script directory ". ./setup.sh".
Then run "node etlDocsMissingPerms.js " to see usage instructions.