### PR TITLE
Custom Sort Docs

### DIFF
--- a/modules/collections/client/directives/collections.reorder.js
+++ b/modules/collections/client/directives/collections.reorder.js
@@ -23,7 +23,7 @@ function reorderCollectionModal($modal, _, CollectionModel, AlertService) {
 					templateUrl: 'modules/collections/client/views/modal-collections-reorder.html',
 					controllerAs: 'vmm',
 					size: 'lg',
-					windowClass: 'fs-modal',
+					windowClass: 'doc-sort-order-modal fs-modal',
 					controller: function ($modalInstance) {
 						var vmm = this;
 						vmm.busy = false;

--- a/modules/collections/client/scss/collections.scss
+++ b/modules/collections/client/scss/collections.scss
@@ -1,20 +1,4 @@
-
-.collections-view {
-    section {
-        margin-bottom: 3rem;
-
-        h2 {
-            font-size: 2rem;
-        }
-    }
-
-    .main-doc-section {
-        .ng-table-pager {
-            display: none;
-        }
-    }
-}
-
+.collections-view,
 .collections-edit {
     section {
         margin-bottom: 3rem;
@@ -31,12 +15,13 @@
     }
 }
 
-/**
- * An element with .dndPlaceholder class will be
- * added to the dnd-list while the user is dragging
- * over it.
- */
-
+.collections-edit {
+    .main-doc-section {
+        .ng-table-pager {
+            display: none;
+        }
+    }
+}
 
 .collection-header {
     background-color: #fff;
@@ -48,65 +33,10 @@
     padding: 10px 15px;
 }
 
-.sort-icon:hover {
-    background: #fff;
-}
-
-.sort-icon {
-    display: inline-block;
-    margin-top: -2px;
-    margin-left: 0.25rem;
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 5px 5px 0 5px;
-    border-color: #494949 transparent transparent transparent;
-    vertical-align: middle;
-}
-
-.sort-icon-descending {
-    border-width: 0 5px 5px 5px;
-    border-color: transparent transparent #494949 transparent;
-}
-
 .collection-document {
     display: flex;
     flex-flow: row wrap;
     justify-content: flex-start;
-}
-
-.collection-document .rank {
-    flex: 0 0 2rem;
-}
-
-.collection-document .name {
-    flex: 1 1 20%;
-}
-
-.collection-document .date {
-    flex: 0 1 10%;
-}
-.collection-document .status {
-    flex: 0 1 8%;
-}
-.collection-document .actions {
-    flex: 0 1 5%;
-}
-
-@media (min-width: 768px) {
-    .collection-document .name {
-        flex: 1 1 20rem;
-    }
-
-    .collection-document .date {
-        flex: 0 1 15rem;
-    }
-    .collection-document .status {
-        flex: 0 1 15rem;
-    }
-    .collection-document .actions {
-        flex: 0 1 2rem;
-    }
 }
 
 @media (max-width: 480px) {
@@ -115,112 +45,18 @@
     }
 }
 
-$dnd-selected-color: #FFF;
-$dnd-selected-bg: #5091cd;
-$dnd-selected-hover-bg: #4187c9;
-$dnd-selected-border: 1px solid #4187c9;
+@media (min-width: 768px) {
+    .collection-document {
+        .date {
+            flex: 0 1 15rem;
+        }
 
-$dnd-placeholder-height: 0.5rem;
-$dnd-drag-target-height: 2.5rem;
+        .name {
+            flex: 1 1 auto;
+        }
 
-.fs-modal {
-    .modal-dialog {
-        position: fixed;
-        top: 2rem;
-        right: 2rem;
-        bottom: 2rem;
-        left: 2rem;
-        margin: 0;
-        overflow: hidden;
-        width: auto;
-
-        .modal-content {
-            @include flexbox();
-            @include flexdirection(column);
-            height: 100%;
-
-            .modal-header,
-            .modal-footer {
-                @include flex(0 0 auto);
-            }
-
-            .modal-body {
-                @include flex(1 1 auto);
-                position: relative;
-            }
+        .status {
+            flex: 0 1 15rem;
         }
     }
-}
-
-.dnd-sort-list {
-    @include flexbox();
-    @include flexdirection(column);
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-
-    [class^="dnd-drag-target"] {
-        height: $dnd-drag-target-height;
-        background: #ddd;
-        //opacity: 0.5;
-    }
-
-    .dnd-drag-target-top {
-        @include flex(0 0 auto);
-        background: #eee;
-        //margin-bottom: calc( #{$dnd-drag-target-height} * -1);
-    }
-
-    .dnd-scroll-container {
-        @include flex(1 1 auto);
-        overflow-y: auto;
-        background: #fff;
-
-        ul {
-            margin: 0;
-            padding: 0;
-            list-style-type: none;
-        }
-    }
-
-    .dnd-row {
-        padding: 2rem;
-        border-bottom: 1px solid #eee;
-
-        &.selected {
-            color: $dnd-selected-color;
-            border-bottom: $dnd-selected-border;
-            background-color: $dnd-selected-bg;
-
-            &:hover {
-                background-color: $dnd-selected-hover-bg;
-            }
-        }
-    }
-
-    .dnd-drag-target-bottom  {
-        @include flex(0 0 auto);
-       // margin-top: calc( #{$dnd-drag-target-height} * -1);
-    }
-}
-
-.dndDragging {
-    padding: 0;
-    color: $dnd-selected-color;
-    background-color: $dnd-selected-bg;
-    opacity: 1 !important;
-}
-
-.dndDraggingSource {
-    display: none;
-}
-
-.dndPlaceholder {
-    padding: 2rem;
-    //margin: -1rem 0;
-    //height: 2rem;
-    background: #5091cd !important;
-    opacity: 0.5;
 }

--- a/modules/collections/client/views/collection-view.html
+++ b/modules/collections/client/views/collection-view.html
@@ -85,12 +85,12 @@
                                 title="Reorder"
                                 x-reorder-collection-modal x-collection="collection" x-on-save="otherDocsReordered">
                             <span class="glyphicon glyphicon-sort"></span>
-                            <span>Reorder</span>
+                            <span>Re-order Documents</span>
                         </button>
                     </div>
                     <div class="table-container">
                         <table class="table" ng-table="otherTableParams">
-                            <tr ng-repeat="d in $data" ng-click="goToDocument(d.document)">
+                            <tr ng-repeat="d in $data">
                                 <td data-title="'Name'" title='Name' sortable="'Name'">{{ d.document.displayName | removeExtension }}</td>
                                 <td data-title="'Date'" title='Date' sortable="'Date'">{{ d.document.documentDate | amDateFormat:'MMMM DD, YYYY' }}</td>
                                 <td class="actions-col" header-class="'actions-col x1'">

--- a/modules/collections/client/views/collections-reorder-content.html
+++ b/modules/collections/client/views/collections-reorder-content.html
@@ -1,23 +1,34 @@
 <div class="dnd-drag-target-top" dnd-scroll-area dnd-region="top" dnd-scroll-container="collectionList"></div>
+<ul id="collectionList"
+    dnd-list 
+    dnd-drop="vm.onDrop(item, index)">
+    <li class="dnd-row" ng-repeat="item in vm.list" id="{{'dc0-' + item.document._id}}" ng-class="{'selected': item.selected}"
+        dnd-draggable="vm.getSelectedItemsIncluding(item)"
+        dnd-dragstart="vm.onDragstart( event, 'dc0-')"
+        dnd-moved="vm.onMoved()"
+        dnd-dragend="vm.onDragend(event)"
+        dnd-selected="item.selected = !item.selected"
+        ng-hide="vm.dragging && item.selected">
 
-<div class="dnd-scroll-container" id="collectionList">
-    <ul dnd-list dnd-drop="vm.onDrop(item, index)">
-        <li class="dnd-row" ng-repeat="item in vm.list" id="{{'dc0-' + item.document._id}}" ng-class="{'selected': item.selected}"
-            dnd-draggable="vm.getSelectedItemsIncluding(item)" 
-            dnd-dragstart="vm.onDragstart( event, 'dc0-')" 
-            dnd-moved="vm.onMoved()"
-            dnd-dragend="vm.onDragend(event)" 
-            dnd-selected="item.selected = !item.selected" 
-            ng-hide="vm.dragging && item.selected">
-            <div class="collection-document">
-                <div class="name">{{ item.document.displayName }}</div>
-                <div class="date">{{ item.document.documentDate | date: 'y-MM-dd' }}</div>
-                <div class="status">
-                    <span class="label label-default" ng-class="{'label-success' : item.document.isPublished }">{{ item.document.isPublished ? 'PUBLISHED' : 'UNPUBLISHED' }}</span>
-                </div>
-            </div>
-        </li>
-    </ul>
-</div>
+        <div class="dnd-row-inner">
+            <span class="dnd-handle">
+                <span class="glyphicon glyphicon-sort"></span>
+            </span>
 
+            <span class="dnd-content">
+                <span class="col avatar">
+                    <span class="fb-file glyphicon glyphicon-file"></span>
+                </span>
+                <span class="col name">{{ item.document.displayName }}</span>
+                <span class="col date">{{ item.document.documentDate | date: 'y-MM-dd' }}</span>
+                <span class="col status">
+                    <span class="label label-unpublished" ng-if="!item.document.isPublished">{{ item.document.isPublished ? 'PUBLISHED' : 'UNPUBLISHED' }}</span>
+                    <span class="label label-success" ng-if="item.document.isPublished">{{ item.document.isPublished ? 'PUBLISHED' : 'UNPUBLISHED' }}</span>
+                </span>
+
+            </span>
+        </div>
+    </li>
+    <li class="dndPlaceholder"><span class="glyphicon glyphicon-arrow-right"></span> Move here<li>
+</ul>
 <div class="dnd-drag-target-bottom" dnd-scroll-area dnd-region="bottom" dnd-scroll-container="collectionList"></div>

--- a/modules/collections/client/views/modal-collections-reorder.html
+++ b/modules/collections/client/views/modal-collections-reorder.html
@@ -1,11 +1,20 @@
 
 <div class="modal-header">
     <button class="btn btn-default close" ng-click="vmm.cancel()"><span aria-hidden="true">×</span></button>
-    <h3 class="modal-title">Select and drag files to re-order</h3>
+    <h3 class="modal-title">Set Document Order</h3>
 </div>
 
 <div class="modal-body">
-    <x-reorder-collection-content class="dnd-sort-list" x-list="vmm.list"></x-reorder-collection-content>
+    <div class="doc-sort-header fb-list">
+        <div class="column-header">
+            <div class="col name">Name</div>
+            <div class="col date">Document Date</div>
+            <div class="col status">Status</div>
+        </div>
+    </div>
+    <div class="doc-sort-scroll-container">
+        <x-reorder-collection-content class="dnd-sort-list" x-list="vmm.list"></x-reorder-collection-content>
+    </div>
 </div>
 
 <div class="modal-footer">

--- a/modules/core/client/scss/components/buttons.scss
+++ b/modules/core/client/scss/components/buttons.scss
@@ -1,0 +1,56 @@
+$radio-btn-bg: #fff;
+$radio-btn-border-color: #ccc;
+$radio-btn-active-color: #fff;
+$radio-btn-active-bg: #5091cd;
+
+.radio-btn-group {
+    @include clearfix();
+    display: inline-block;
+
+    .radio-btn {
+        float: left;
+        margin-left: -1px;
+        cursor: pointer;
+
+        label.btn {
+            position: relative;
+            border-radius: 0;
+
+            .glyphicon {
+                margin-bottom: 0.4rem;
+                margin-right: 0.5rem;
+                vertical-align: middle;
+            }
+        }
+
+        &:first-child {
+            label.btn {
+                border-top-left-radius: 0.4rem;
+                border-bottom-left-radius: 0.4rem;
+            }
+        }
+        &:last-child {
+            label.btn {
+                border-top-right-radius: 0.4rem;
+                border-bottom-right-radius: 0.4rem;
+            }
+        }
+
+        input[type="radio"] {
+            display: none;
+
+            &:checked {
+                + label {
+                    color: $radio-btn-active-color;
+                    border-color: $radio-btn-active-bg;
+                    background: $radio-btn-active-bg;
+                    z-index: 2;
+                }
+            }
+        }
+    }
+
+    + .radio-btn-group {
+        margin-left: 1rem;
+    }
+}

--- a/modules/core/client/scss/components/drag-and-drop.scss
+++ b/modules/core/client/scss/components/drag-and-drop.scss
@@ -1,0 +1,98 @@
+$dnd-row-border: 1px solid #eee;
+$dnd-selected-color: #FFF;
+$dnd-selected-bg: #5091cd;
+$dnd-selected-hover-bg: #4187c9;
+$dnd-selected-border: 1px solid #4187c9;
+$dnd-placeholder-height: 0.5rem;
+$dnd-drag-target-height: 2.5rem;
+$dnd-drag-target-bg: #fff;
+
+.dnd-sort-list {
+    .dnd-drag-target-top {
+        @include flex(0 0 auto);
+    }
+
+    .dnd-drag-target-bottom  {
+        @include flex(0 0 auto);
+    }
+}
+
+ul[dnd-list] {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+
+    .dndDraggingSource {
+        display: none;
+    }
+
+    &.dndDragover {
+        .dnd-row {
+            &:hover {
+                background-color: transparent;
+            }
+        }
+    }
+}
+
+.dnd-row {
+    @include userselect(none);
+    border-bottom: $dnd-row-border;
+
+    .dnd-row-inner {
+        @include flexbox();
+    
+        .dnd-handle {
+            @include flex(0);
+            position: relative;
+            padding: 1.25rem 0;
+            width: 0;
+            opacity: 0;
+            text-align: center;
+            transition: flex ease-out 0.25s;
+            border-right: $dnd-row-border; 
+        }
+
+        .dnd-content {
+            @include flex(1 1 auto);
+            @include flexbox();
+        }
+    }
+
+    &.selected {
+        color: $dnd-selected-color;
+        border-bottom: $dnd-selected-border;
+        background-color: $dnd-selected-bg;
+
+        .dnd-row-inner {
+            .dnd-handle {
+                border-right: $dnd-selected-border;
+            }
+        }
+
+        &:hover {
+            background-color: $dnd-selected-hover-bg;
+        }
+    }
+
+    &[draggable = true] {
+        cursor: move;
+
+        .dnd-handle {
+            @include flex(0 1 5rem);
+            opacity: 1;
+        }
+    }
+}
+
+.dndPlaceholder {
+    padding: 1.5rem 2rem;
+    color: $dnd-selected-color;
+    border-bottom: 1px solid $dnd-selected-bg;
+    background: $dnd-selected-bg !important;
+    font-weight: bold;
+
+    .glyphicon {
+        margin-right: 1rem;
+    }
+}

--- a/modules/core/client/scss/components/modal.scss
+++ b/modules/core/client/scss/components/modal.scss
@@ -1,0 +1,29 @@
+// Full Screen Modal Variant
+.fs-modal {
+    .modal-dialog {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        bottom: 1rem;
+        left: 1rem;
+        margin: 0;
+        overflow: hidden;
+        width: auto;
+
+        .modal-content {
+            @include flexbox();
+            @include flexdirection(column);
+            height: 100%;
+
+            .modal-header,
+            .modal-footer {
+                @include flex(0 0 auto);
+            }
+
+            .modal-body {
+                @include flex(1 1 auto);
+                position: relative;
+            }
+        }
+    }
+}

--- a/modules/core/client/scss/core.scss
+++ b/modules/core/client/scss/core.scss
@@ -4314,7 +4314,10 @@ tmpl-template-render {
 
 // COMPONENTS
 @import "modules/core/client/scss/components/accordion.scss";
+@import "modules/core/client/scss/components/buttons.scss";
+@import "modules/core/client/scss/components/drag-and-drop.scss";
 @import "modules/core/client/scss/components/file-browser.scss";
+@import "modules/core/client/scss/components/modal.scss";
 @import "modules/core/client/scss/components/panel.scss";
 @import "modules/core/client/scss/components/misc.scss";
 @import "modules/core/client/scss/components/pdf-viewer.scss";
@@ -4332,6 +4335,7 @@ tmpl-template-render {
 // MODULES
 @import "modules/codelists/client/scss/codelist.scss";
 @import "modules/collections/client/scss/collections.scss";
+@import "modules/documents/client/scss/document-manager.scss";
 @import "modules/communications/client/scss/communications.scss";
 @import "modules/invitations/client/scss/invitations.scss";
 @import "modules/projects/client/scss/project-schedule.scss";

--- a/modules/core/client/scss/global/mixins.scss
+++ b/modules/core/client/scss/global/mixins.scss
@@ -1,4 +1,13 @@
 
+// Mixins
+@mixin clearfix() {
+    &::after {
+    display: block;
+    content: "";
+    clear: both;
+  }
+}
+
 @mixin flexbox() {
 	display: -webkit-box;
 	display: -ms-flexbox;
@@ -33,5 +42,9 @@
 }
 
 @mixin userselect($values) {
-    user-select: $values;
+	-webkit-touch-callout: $values;
+	-webkit-user-select: $values;
+	-moz-user-select: $values;
+	-ms-user-select: $values;
+	user-select: $values;
 }

--- a/modules/documents/client/directives/documents.reorder.js
+++ b/modules/documents/client/directives/documents.reorder.js
@@ -1,0 +1,471 @@
+"use strict";
+angular.module('control')
+.directive("reorderDocumentsModal", // x-reorder-documents-modal
+		['$modal', '$timeout', '_', 'AlertService', 'ConfirmService', 'moment', 'FolderModel', 'Document', reorderDocumentsModal])
+.directive('reorderDocumentsContent', // x-reorder-documents-content
+		[reorderDocumentsContent ])
+.controller("documentsSortingController", documentsSortingController);
+
+function reorderDocumentsModal($modal, $timeout, _,  AlertService, ConfirmService, moment, FolderModel, Document) {
+	var CUSTOM     = 'custom',
+		DATE         = 'date',
+		NAME         = 'name',
+		DOCUMENT     = 'document',
+		FOLDER       = 'folder',
+		ASCENDING    = 'ascending',
+		DESCENDING   = 'descending',
+		ASC          = 'asc',
+		DESC         = 'desc',
+		TITLE        = "Please confirm",
+		WARNING      = "Warning",
+		CONFIRM_CUST = "This will override any custom sorting.",
+		CONFIRM_APP  = "All subfolders will be sorted by %option%. This will override any custom sorting.";
+	return {
+		restrict: 'A',
+		scope: {
+			options:      '=',
+			currentPath:  '=',
+			folder:       '=',
+			onSave:       '='
+		},
+		link: function (scope, element, attributes) {
+			element.on('click', function () {
+				$modal.open({
+					animation:     true,
+					templateUrl:   'modules/documents/client/views/partials/modal-document-reorder.html',
+					controllerAs:  'vmm',
+					size:          'lg',
+					backdrop:      'static',
+					keyboard:      false,
+					windowClass:   'doc-sort-order-modal fs-modal',
+					controller: function ($modalInstance) {
+						var self                  = this;
+						self.busy                 = false;
+						self.ok                   = submit;
+						self.cancel               = cancel;
+						self.setDefaultSortOrder  = setDefaultSortOrder;
+						self.applySort            = applySort;
+						self.checkSelectItem      = checkSelectItem;
+						self.onSaveCallback       = scope.onSave;
+						self.currentPath          = scope.currentPath;
+						self.options              = scope.options;
+						self.folder               = scope.folder;
+						self.sorting              = {};
+						self.applyToChildren      = false;
+						self.documents            = { id: DOCUMENT, allowedTypes: [DOCUMENT], items: []};
+						self.folders              = { id: FOLDER, allowedTypes: [FOLDER], items: []};
+						self.pendingSubfolders    = 0;
+						loadDocumentsAndFolders();
+						var column             = self.folder.defaultSortField,
+							defaultSortDirection = self.folder.defaultSortDirection,
+							key                  = composeKey(column, defaultSortDirection);
+						applySort(key, column, defaultSortDirection);
+
+						// UI is ready for user. Load the subfolders in the background.
+						$timeout(loadSubfolders,0);
+
+						// what follows are the helper functions...
+
+						function loadDocumentsAndFolders () {
+							//deep'ish copy of original list of documents. We can sort this without affecting the original
+							_.forEach(self.options.documents, function (doc) {
+								var d = {};
+								d._id = doc._id;
+								d.displayName = doc.displayName;
+								d.documentDate = doc.dateUploaded; // EPIC uses dateUploaded MEM uses documentDate
+								d.documentDateDisplayMnYr = doc.documentDateDisplayMnYr;
+								d.isPublished = doc.isPublished;
+								d.type = DOCUMENT;
+								self.documents.items.push(d);
+							});
+							_.forEach(self.options.folders, function (doc) {
+								var d = {};
+								d._id = doc.model.folderObj._id;
+								d.displayName = doc.model.name;
+								d.documentDate = null;
+								d.documentDateDisplayMnYr = false;
+								d.order = doc.model.order;
+								d.isPublished = doc.model.published;
+								d.type = FOLDER;
+								self.folders.items.push(d);
+							});
+						}
+
+						function composeKey(column, direction) {
+							var key;
+							if (column === NAME) {
+									key = NAME + '-' + direction;
+							}
+							if (column === DATE) {
+								key = DATE + '-' + direction;
+							}
+							if (column === CUSTOM) {
+								key = CUSTOM;
+							}
+							return key;
+						}
+
+						function setDefaultSortOrder (sortKey) {
+							var column, defaultSortDirection;
+							switch(sortKey) {
+								case 'date-asc':
+									column = DATE;
+									defaultSortDirection = ASC;
+									break;
+								case 'date-desc':
+									column = DATE;
+									defaultSortDirection = DESC;
+									break;
+								case 'name-asc':
+									column = NAME;
+									defaultSortDirection = ASC;
+									break;
+								case 'name-desc':
+									column = NAME;
+									defaultSortDirection = DESC;
+									break;
+								case CUSTOM:
+									column = CUSTOM;
+									defaultSortDirection = '';
+									break;
+							}
+							if (self.sorting.column === CUSTOM && column !== CUSTOM) {
+								ConfirmService.confirmDialog({
+									titleText: WARNING,
+									confirmText: CONFIRM_CUST,
+									onOk: function () {
+										_.forEach(self.folders.items, function (item) {
+											item.selected = false;
+										});
+										_.forEach(self.documents.items, function (item) {
+											item.selected = false;
+										});
+										self.applySort(sortKey, column, defaultSortDirection);
+										return Promise.resolve();
+									},
+									onCancel: function () {
+										// restore radio buttons ...
+										self.defaultSortColumn = self.sorting.sortKey;
+										return Promise.resolve();
+									}
+								});
+							} else {
+								self.applySort(sortKey, column, defaultSortDirection);
+							}
+						}
+
+						function checkSelectItem (listHolder, item) {
+							if (self.customSorting) {
+								var listId = listHolder.id;
+								var theOtherListHolder = listId === FOLDER ? self.documents : self.folders;
+								var list = listHolder.items;
+								if (item.selected === false) {
+									// user wants to select this item
+									if (theOtherListHolder.isActive) {
+										_.forEach(theOtherListHolder.items, function (other) {
+											other.selected = false;
+										});
+										theOtherListHolder.isActive = false;
+									}
+									item.selected = true;
+									listHolder.isActive = true;
+								} else {
+									// user wants to unselect this item. But now that one item is unselected
+									// do we need to deactivate the list?
+									item.selected = false;
+									var found = _.find(list, function (a) {
+										return a.selected;
+									});
+									if (!found) {
+										listHolder.isActive = false;
+									}
+								}
+							}
+						}
+
+						function applySort(sortKey, column, defaultSortDirection) {
+							self.busy = true;
+							self.sorting.sortKey              = sortKey;
+							self.defaultSortColumn            = sortKey;
+							self.sorting.column               = column;
+							self.sorting.defaultSortDirection = defaultSortDirection;
+							if (column === CUSTOM) {
+								self.sortDescription = '';
+								self.customSorting   = true;
+								self.applyToChildren = false;
+
+							} else {
+								self.sortDescription = self.sorting.column + ' ' + (defaultSortDirection === ASC ? ASCENDING : DESCENDING);
+								self.customSorting   = false;
+							}
+							var direction = self.sorting.defaultSortDirection === ASC ? 1 : -1;
+							var collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
+							if (self.sorting.column === NAME) {
+								self.documents.items.sort(function (d1, d2) {
+									var v = collator.compare(d1.displayName, d2.displayName);
+									return v * direction;
+								});
+								self.folders.items.sort(function (d1, d2) {
+									var v = collator.compare(d1.displayName, d2.displayName);
+									return v * direction;
+								});
+							} else if (self.sorting.column === DATE) {
+								self.documents.items.sort(function(doc1, doc2){
+									/*
+									 Sort by date but account for the case the display value is like June 2017.
+									 We want to group all June 2017 docs before any like 2017-01-01.
+									 */
+									var d1 = doc1.documentDate ? {d: moment(doc1.documentDate), my: doc1.documentDateDisplayMnYr} : undefined;
+									var d2 = doc2.documentDate ? {d: moment(doc2.documentDate), my: doc2.documentDateDisplayMnYr} : undefined;
+									if (d1 && d2 && d1.d.isSame(d2.d,'month')) {
+										if (d1.my && d2.my) {
+											return (d1.d.valueOf() - d2.d.valueOf()) * direction;
+										} else if (d1.my) {
+											return -1 * direction;
+										}  else if (d2.my) {
+											return 1 * direction;
+										}
+									}
+									d1 = d1 ? d1.d.valueOf() : 0;
+									d2 = d2 ? d2.d.valueOf() : 0;
+									return (d1 - d2) * direction;
+								});
+							}
+							self.busy = false;
+						}
+
+						function loadSubfolders() {
+							/*
+							The project directory structure only has the skelton of the folder structure. This skelton
+							only has the actual folder objects for the immediate children of the parent folder. But when
+							we need to apply the sort options to all subfolders we'll need to have the folder object
+							for each.   In this function we walk the tree looking for any subfolder models that need
+							the actual folder object. This code can be ripped out if the over all system collects these
+							subfolders somewhere else (e.g. on page load).
+							 */
+							var theKids = [];
+							var node = self.currentPath[self.currentPath.length-1];
+							node.walk( function (child) {
+								theKids.push(child);
+							});
+							_.forEach(theKids, function (child) {
+								if (!child.model.hasOwnProperty('folderObj')) {
+									// console.log("This child needs folder obj", child.model.name);
+									self.pendingSubfolders++;
+									FolderModel.lookup(self.folder.project, child.model.id)
+									.then(function (folder) {
+										child.model.folderObj = folder;
+										self.pendingSubfolders--;
+									});
+								}
+							});
+						}
+
+						function cancel (event) {
+							if (self.customSorting) {
+								ConfirmService.confirmDialog({
+									titleText: WARNING,
+									confirmText: CONFIRM_CUST,
+									onOk: function () {
+										$modalInstance.dismiss('cancel');
+										return Promise.resolve();
+									},
+									onCancel: function () {
+										return Promise.resolve();
+									}
+								});
+							} else {
+								$modalInstance.dismiss('cancel');
+							}
+						}
+
+						function submit () {
+							if (self.applyToChildren) {
+								ConfirmService.confirmDialog({
+									titleText: WARNING,
+									confirmText: CONFIRM_APP.replace('%option%',self.sortDescription),
+									onOk: function () {
+										self.busy = true;
+										function wait(){
+											if (self.pendingSubfolders === 0 ){
+												submitWorker();
+											} else {
+												// the subfolder loading has not yet completed ...
+												// it is highly unlikely this will happen but we must wait ...
+												// Yes, display a console message in case something has gone wrong.
+												console.log("Waiting for subfolders to load " +self.pendingSubfolders+ " folders to go");
+												$timeout(wait,500);
+											}
+										}
+										wait();
+										// close the confirmation dialog
+										return Promise.resolve();
+									},
+									onCancel: function () {
+										return Promise.resolve();
+									}
+								});
+							} else {
+								submitWorker();
+							}
+						}
+
+						function submitWorker () {
+							self.busy = true;
+							self.folder.defaultSortField = self.sorting.column;
+							self.folder.defaultSortDirection = 	self.sorting.defaultSortDirection;
+							return FolderModel.save(self.folder)
+							.then (function(result) {
+								var list = self.folders.items;
+								if (list.length === 0) {
+									return Promise.resolve();
+								}
+								var ids = [];
+								list.forEach(function(item) {
+									ids.push(item._id);
+								});
+								return FolderModel.sortFolders(self.folder.project, self.folder.directoryID, ids);
+							})
+							.then(function(result) {
+								var list = self.documents.items;
+								if (list.length === 0) {
+									return Promise.resolve();
+								}
+								var ids = [];
+								list.forEach(function(item) {
+									ids.push(item._id);
+								});
+								return Document.sortDocuments(self.folder.project, self.folder.directoryID, ids);
+							})
+							.then(function(result){
+								if (self.applyToChildren) {
+									var theKids = [];
+									var node = self.currentPath[self.currentPath.length-1];
+									node.walk( function (child) {
+										theKids.push(child);
+									});
+									var folderPromises = _.map(theKids, function(child) {
+										var folder = child.model.folderObj;
+										folder.defaultSortField = self.sorting.column;
+										folder.defaultSortDirection = 	self.sorting.defaultSortDirection;
+										//console.log("Save sort to folder " + folder.displayName);
+										return FolderModel.save(folder);
+									});
+									return Promise.all(folderPromises);
+								}
+								else {
+									return Promise.resolve(true);
+								}
+							})
+							.then(function(result) {
+								AlertService.success('Folder changes saved');
+								if (self.onSaveCallback) {
+									self.onSaveCallback();
+								}
+								self.busy = false;
+								$modalInstance.close(self.folder);
+							})
+							.catch(function(res) {
+								console.log("Error:", res);
+								var failure = _.has(res, 'message') ? res.message : '';
+								AlertService.error('Changes not saved. ' + failure);
+								self.busy = false;
+								$modalInstance.close();
+							});
+						}
+					}
+				}).result
+				.then (function() {
+					if (scope.onSave) {
+						scope.onSave();
+					}
+				})
+				.catch(function (err) {
+					if ('cancel' !== err && 'backdrop click' !== err) {
+						console.log("Error in reorderDocumentsModal", err);
+					}
+				});
+			});
+		}
+	};
+}
+
+function reorderDocumentsContent() {
+	var directive = {
+		restrict: 'E',
+		templateUrl: 'modules/documents/client/views/partials/document-reorder-content.html',
+		controller: 'documentsSortingController',
+		controllerAs: 'vm',
+		scope: {
+			list:   '=',
+			title:  '=',
+			parent: '='
+		}
+	};
+	return directive;
+}
+
+
+documentsSortingController.$inject = ['$scope', '$document', '$timeout'];
+/* @ngInject */
+function documentsSortingController($scope, $document, $timeout) {
+	var self                       = this;
+	self.dragging                  = false;
+	self.list                      = $scope.list;
+	self.parent                    = $scope.parent;
+	self.sectionTitle              = $scope.title;
+	self.getSelectedItemsIncluding = getSelectedItemsIncluding;
+	self.onDragstart               = onDragstart;
+	self.onDragend                 = onDragend;
+	self.onDrop                    = onDrop;
+	self.onMoved                   = onMoved;
+	self.onSelect                  = onSelect;
+	self.sorting                   = {};
+
+	self.list.items.forEach(function(item) {
+		item.selected = false;
+	});
+
+	function getSelectedItemsIncluding(item) {
+		item.selected = true;
+		var list = self.list.items.filter(function(item) {
+			return item.selected;
+		});
+		return list;
+	}
+
+	function onSelect(item) {
+		self.parent.checkSelectItem(self.list, item);
+		return true;
+	}
+
+	function onDragstart(event, idPrefix) {
+		self.dragging = true;	
+		return false;
+	}
+
+	function onDragend() {
+		self.dragging = false;
+	}
+
+	function onDrop(items, index) {
+		angular.forEach(items, function(item) {
+			item.selected = false;
+		});
+		self.list.items = self.list.items.slice(0, index)
+		.concat(items)
+		.concat(self.list.items.slice(index));
+		self.list.items.forEach(function(item,index) {
+			item.order = index;
+		});
+		return true;
+	}
+
+	function onMoved() {
+		// remove the items that were just dragged (they are still selected)
+		self.list.items = self.list.items.filter(function(item) {
+			return !item.selected;
+		});
+	}
+}
+

--- a/modules/documents/client/scss/document-manager.scss
+++ b/modules/documents/client/scss/document-manager.scss
@@ -1,0 +1,93 @@
+@import "modules/core/client/scss/global/mixins.scss";
+@import "modules/core/client/scss/global/helpers.scss";
+
+.doc-sort-order-modal {
+    .modal-body {
+        @include flexbox();
+        @include flexdirection(column);
+
+        .btn-toolbar{
+            @include flex(0 0 auto);
+            margin-bottom: 2rem;
+        }
+
+        .doc-sort-container {
+            @include flex(1 1 auto);
+        }
+    }
+}
+
+.doc-sort-header {
+    @include flex(0 0 auto);
+
+    .col {
+        &.date {
+            @include flex(0 0 15rem);
+        }
+    
+        &.name {
+            @include flex(1 1 auto);
+            padding-left: 1.5rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    
+        &.status {
+            @include flex(0 0 15rem);
+            margin-right: 17px;
+        }
+    }
+}
+
+.doc-sort-scroll-container {
+    @include flex(1 1 1px);
+    position: relative;
+    overflow-y: scroll;
+    background: #fff;
+}
+
+.doc-sort-options {
+    @include clearfix();
+
+    .checkbox {
+        margin-top: 0.5rem;
+        margin-bottom: 0;
+        margin-left: 1rem;
+        
+        label {
+            font-size: 1.2rem;
+            font-weight: bold;
+        }
+    }
+}
+
+.dnd-content {
+    .col {
+        padding: 1.25rem 0.5rem;
+
+        &.avatar {
+            @include flex(0);
+            padding: 1.25rem;
+
+            .glyphicon {
+                margin-top: -0.2rem;
+                font-size: 1.8rem;
+                vertical-align: top;
+            }
+        }
+
+        &.date {
+            @include flex(0 0 15rem);
+        }
+
+        &.name {
+            @include flex(1 1 auto);
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        &.status {
+            @include flex(0 0 15rem);
+        }
+    }
+}

--- a/modules/documents/client/services/documents.client.services.js
+++ b/modules/documents/client/services/documents.client.services.js
@@ -211,7 +211,11 @@ angular.module('documents').factory('Document', function (ModelBase, _) {
 		},
 		unpublish: function (document) {
 			return this.put('/api/unpublish/document/' + document._id);
-		}
+		},
+		sortDocuments: function (projectId, parentid, idList) {
+			return this.put('/api/documents/for/project/' + projectId + '/in/' + parentid + '/sort', idList);
+		},
+
 	});
 	return new Class();
 });

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -13,26 +13,39 @@
 			</div>
 		</div>
 		<div class="fb-header-actions">
+			<button class="btn icon-btn" title="Set Default Sort Order"
+				ng-if="project.userCan.manageFolders && documentMgr.currentNode.model.name !== 'ROOT'"
+				x-reorder-documents-modal
+				x-options="documentMgr.customSorter"
+				x-on-save="documentMgr.defaultSortOrderChanged"
+				x-folder="documentMgr.currentNode.model.folderObj"
+				x-current-path="documentMgr.currentPath">
+				<span class="glyphicon glyphicon-sort"></span>
+			</button>
+
 			<button class="btn icon-btn" title="Add New Folder"
-					ng-if="project.userCan.manageFolders"
-					ng-disabled="!documentMgr.selectedNode"
-					x-document-mgr-add-folder
-					x-project="project"
-					x-root="documentMgr.rootNode"
-					x-node="documentMgr.selectedNode"><span class="glyphicon glyphicon-folder-close"></span></button>
+				ng-if="project.userCan.manageFolders"
+				ng-disabled="!documentMgr.selectedNode"
+				x-document-mgr-add-folder
+				x-project="project"
+				x-root="documentMgr.rootNode"
+				x-node="documentMgr.selectedNode"><span class="glyphicon glyphicon-folder-close"></span>
+			</button>
 
 			<button class="btn icon-btn" title="Upload Files"
-					ng-if="project.userCan.createDocument"
-					ng-disabled="!documentMgr.selectedNode"
-					x-document-mgr-upload-modal
-					x-project="project"
-					x-root="documentMgr.rootNode"
-					x-node="documentMgr.selectedNode"
-					x-type="'project'"><span class="glyphicon glyphicon-open"></span></button>
+				ng-if="project.userCan.createDocument"
+				ng-disabled="!documentMgr.selectedNode"
+				x-document-mgr-upload-modal
+				x-project="project"
+				x-root="documentMgr.rootNode"
+				x-node="documentMgr.selectedNode"
+				x-type="'project'"><span class="glyphicon glyphicon-open"></span>
+			</button>
 
 			<button class="toggle-details-btn btn icon-btn" title="Properties"
-					ng-disabled="!documentMgr.lastChecked"
-					ng-click="documentMgr.infoPanel.toggle()"><span class="glyphicon glyphicon-info-sign"></span></button>
+				ng-disabled="!documentMgr.lastChecked"
+				ng-click="documentMgr.infoPanel.toggle()"><span class="glyphicon glyphicon-info-sign"></span>
+			</button>
 
 			<a class="btn icon-btn" href="{{documentMgr.folderURL}}" title="Sharable Link to this folder"><span class="glyphicon glyphicon-link"></span></a>
 
@@ -125,10 +138,6 @@
 					<div class="col name-col first-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('name')">
 						<span>Name</span>
 						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'name'"></span>
-					</div>
-					<div hidden class="col author-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('author')">
-						<span>Author</span>
-						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'author'"></span>
 					</div>
 					<div class="col date-added-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('date')">
 						<span>Uploaded</span>

--- a/modules/documents/client/views/partials/document-reorder-content.html
+++ b/modules/documents/client/views/partials/document-reorder-content.html
@@ -1,0 +1,44 @@
+<!-- <div class="dnd-drag-target-top"></div> -->
+
+<ul id="{{'dnd-' + vm._id}}" 
+    dnd-list 
+    dnd-allowed-types="vm.list.allowedTypes"
+    dnd-drop="vm.onDrop(item, index)">
+
+    <li class="dnd-row" ng-class="{'selected': item.selected}"
+        ng-repeat       = "item in vm.list.items"
+        id              = "{{'dc0-' + item._id}}"
+        dnd-draggable   = "vm.getSelectedItemsIncluding(item)"
+        dnd-type        = "item.type"
+        dnd-effect-allowed ="move"
+        dnd-dragstart   = "vm.onDragstart( event, 'dc0-')"
+        dnd-moved       = "vm.onMoved()"
+        dnd-dragend     = "vm.onDragend(event)"
+        dnd-selected    = "vm.onSelect(item)"
+        dnd-disable-if  = "!vm.parent.customSorting"
+        ng-hide         = "vm.dragging && item.selected">
+
+        <div class="dnd-row-inner">
+            <span class="dnd-handle">
+                <span class="glyphicon glyphicon-sort"></span>
+            </span>
+
+            <!-- Custom Content -->
+            <span class="dnd-content">
+                <span class="col avatar">
+                    <span class="fb-folder glyphicon glyphicon-folder-close" ng-if="item.type === 'folder'"></span>
+                    <span class="fb-file glyphicon glyphicon-file" ng-if="item.type === 'document'"></span>
+                </span>
+                <span class="col name">{{ item.displayName }}</span>
+                <span class="col date">{{ item.documentDate |  date : format : timezone }}</span>
+                <span class="col status">
+                    <span class="label label-unpublished" ng-if="!item.isPublished">{{ item.isPublished ? 'PUBLISHED' : 'UNPUBLISHED' }}</span>
+                    <span class="label label-success" ng-if="item.isPublished">{{ item.isPublished ? 'PUBLISHED' : 'UNPUBLISHED' }}</span>
+                </span>
+
+            </span>
+        </div>
+    </li>
+    <li class="dndPlaceholder"><span class="glyphicon glyphicon-arrow-right"></span> Move here<li>
+</ul>
+

--- a/modules/documents/client/views/partials/modal-document-reorder.html
+++ b/modules/documents/client/views/partials/modal-document-reorder.html
@@ -1,0 +1,83 @@
+<div class="modal-header">
+	<button class="btn btn-default close" ng-click="vmm.cancel()"><span aria-hidden="true">×</span></button>
+	<h3 class="modal-title">Set Default Sort Order > {{vmm.folder.displayName}}</h3>
+</div>
+
+<div class="modal-body">
+	<div class="btn-toolbar doc-sort-options">
+		<div class="radio-btn-group btn-group">
+			<div class="radio-btn">
+				<input type="radio" name="defaultSort" id="nameAsc" value="name-asc" ng-model="vmm.defaultSortColumn" ng-click="vmm.setDefaultSortOrder('name-asc')"/>
+				<label class="btn btn-default btn-sm" for="nameAsc">
+					<span class="glyphicon glyphicon-sort-by-alphabet"></span>
+					Name Ascending
+				</label>
+			</div>
+			<div class="radio-btn">
+				<input type="radio" name="defaultSort" id="nameDesc" value="name-desc" ng-model="vmm.defaultSortColumn" ng-click="vmm.setDefaultSortOrder('name-desc')"/>
+				<label class="btn btn-default btn-sm" for="nameDesc">
+					<span class="glyphicon glyphicon-sort-by-alphabet-alt"></span>
+					Name Descending
+				</label>
+			</div>
+			<div class="radio-btn">
+				<input type="radio" name="defaultSort" id="dateAsc" value="date-asc" ng-model="vmm.defaultSortColumn" ng-click="vmm.setDefaultSortOrder('date-asc')"/>
+				<label class="btn btn-default btn-sm" for="dateAsc">
+					<span class="glyphicon glyphicon glyphicon-sort-by-attributes"></span>
+					Date Ascending
+				</label>
+			</div>
+			<div class="radio-btn">
+				<input type="radio" name="defaultSort" id="dateDesc" value="date-desc" ng-model="vmm.defaultSortColumn" ng-click="vmm.setDefaultSortOrder('date-desc')"/>
+				<label class="btn btn-default btn-sm" for="dateDesc">
+					<span class="glyphicon glyphicon glyphicon-sort-by-attributes-alt"></span>
+					Date Descending
+				</label>
+			</div>
+			<div class="radio-btn">
+				<input type="radio" name="defaultSort" id="custom" value="custom" ng-model="vmm.defaultSortColumn" ng-click="vmm.setDefaultSortOrder('custom')"/>
+				<label class="btn btn-default btn-sm" for="custom">Custom Order</label>
+			</div>
+		</div>
+		<div class="btn-group" ng-if="!vmm.customSorting">
+			<div class="checkbox">
+				<label>
+					<input type="checkbox" id="applyToChildren" ng-model="vmm.applyToChildren" /> Apply {{vmm.sortDescription}} to all subfolders
+				</label>
+			</div>
+		</div>
+	</div>
+
+	<div class="doc-sort-header fb-list">
+		<div class="column-header">
+			<div class="col name">Name</div>
+			<div class="col date">Document Date</div>
+			<div class="col status">Status</div>
+		</div>
+	</div>
+
+	<div class="doc-sort-scroll-container">
+		<x-reorder-documents-content class="dnd-sort-list doc-sort-folders"
+      ng-class="{'active' : vmm.folders.isActive}"
+			x-list="vmm.folders"
+			x-parent="vmm"
+			x-title="'Folders'">
+		</x-reorder-documents-content>
+
+		<x-reorder-documents-content class="dnd-sort-list doc-sort-files"
+			x-list="vmm.documents"
+			x-parent="vmm"
+			x-title="'Documents'">
+		</x-reorder-documents-content>
+
+	</div>
+</div>
+
+<div class="modal-footer">
+	<button class="btn btn-default" ng-click="vmm.cancel($event)">Cancel</button>
+	<button class="btn btn-primary" ng-click="vmm.ok()">Save</button>
+</div>
+
+<div class="spinner-container" ng-show="vmm.busy">
+  <div class="spinner-new rotating"></div>
+</div>

--- a/modules/documents/server/models/document.model.js
+++ b/modules/documents/server/models/document.model.js
@@ -135,7 +135,7 @@ module.exports = genSchema ('Document', {
 	internalSize            : { type:Number, default:0 },
 	internalEncoding        : { type:String, default:'' },
 	oldData                 : { type:String, default:'' },
-	order                   : { type: Number, default: 0}, // this will be used to sort supporting documents in artifacts, the order will be arbitrary and determined by the user.
+	order                   : { type: Number, default: Date.now},
 	eaoStatus               : { type:String, default:'', enum:['', 'Unvetted', 'Rejected', 'Deferred', 'Accepted', 'Published', 'Spam'] },// for use with Public Comment Attachments...
 
 	relatedDocuments        : [ { type: 'ObjectId', ref: 'Document' } ],

--- a/modules/documents/server/routes/core.document.routes.js
+++ b/modules/documents/server/routes/core.document.routes.js
@@ -61,6 +61,11 @@ module.exports = function (app) {
 		.get (routes.setAndRun (DocumentClass, function (model, req) {
 			return model.getDocumentsForProject (req.params.projectid, req.headers.reviewdocsonly);
 		}));
+	app.route ('/api/documents/for/project/:projectid/in/:directoryid/sort')
+		.all (policy ('guest'))
+		.put (routes.setAndRun (DocumentClass, function (model, req) {
+			return model.sortDocumentsForProjectFolder (req.params.projectid, req.params.directoryid, req.body);
+	}));
 	//
 	// getProjectDocumentTypes         : '/api/documents/types/' + projectId
 	//

--- a/modules/folders/client/services/folders.client.services.js
+++ b/modules/folders/client/services/folders.client.services.js
@@ -9,7 +9,10 @@ angular.module('folders').factory ('FolderModel', function (ModelBase, _) {
         },
         lookup: function (projectId, folderId) {
             return this.get('/api/folders/for/project/' + projectId + '/' + folderId);
-        }
+        },
+        sortFolders: function (projectId, parentid, idList) {
+            return this.put('/api/folders/for/project/' + projectId + '/in/' + parentid + '/sort', idList);
+        },
     });
     return new Class ();
 });

--- a/modules/folders/server/controllers/core.folder.controller.js
+++ b/modules/folders/server/controllers/core.folder.controller.js
@@ -77,6 +77,45 @@ module.exports = DBModel.extend ({
 				})
 				.then(resolve, reject);
 		});
-	}
+	},
+
+
+	sortFolders: function (projectId, parentId, idList) {
+		var self = this;
+		return this.list ({project: projectId, parentID: parentId},{order:1})
+		.then(function (folders) {
+			if (!idList || !Array.isArray(idList) || idList.length === 0) { throw new Error('Missing id list'); }
+			if (folders.length === 0) { throw new Error('No subfolders in parent ' + parentId); }
+			// shallow copy array
+			var toSortList = folders.slice();
+			var document, index = 0;
+			idList.forEach(function (id) {
+				var foundIndex = toSortList.findIndex(function (item) {
+					return item._id.toString() === id;
+				});
+				if (foundIndex > -1) {
+					document = toSortList[foundIndex];
+					// update the document
+					document.order = index++;
+					document.save();
+					// remove the found item from the temporary list
+					toSortList.splice(foundIndex, 1);
+				}
+			});
+			if (toSortList.length > 0) {
+				/*
+						Handle items not in the passed in list of ids.  E.g. Two users working on collection.
+						One is sorting the other is adding or removing documents. Both start from the same list but the second
+						user submits the new document list before the first user finishes sorting.  We make sure the newly added
+						documents are at the bottom of the new list.
+				 */
+				toSortList.forEach(function (document) {
+					document.order = index++;
+					document.save();
+				});
+			}
+		});
+	},
+
 });
 

--- a/modules/folders/server/models/folder.model.js
+++ b/modules/folders/server/models/folder.model.js
@@ -18,8 +18,9 @@ module.exports = require (path.resolve('./modules/core/server/controllers/core.s
 	dateAdded 	: { type: Date, default: Date.now },
 	dateUpdated : { type: Date, default: Date.now },
 	documentDate: { type: Date, default: Date.now },
-
 	updatedBy 	: { type:'ObjectId', ref:'User', default:null },
-	order 		: { type: Number, default: 0},
+	defaultSortField     : { type:String, enum:['name', 'date', 'custom', ''], default:'' },
+	defaultSortDirection : { type:String, enum:['asc', 'desc', ''], default:'' },
+	order 		           : { type: Number, default: Date.now},
 	keywords 	: [ { type:'String'} ]
 });

--- a/modules/folders/server/routes/core.folder.routes.js
+++ b/modules/folders/server/routes/core.folder.routes.js
@@ -32,5 +32,11 @@ module.exports = function (app) {
 		.put(routes.setAndRun(FolderClass, function (model, req) {
 			return model.unpublish(req.Folder);
 		}));
+	app.route('/api/folders/for/project/:projectid/in/:parentid/sort')
+		.all(policy('user'))
+		.put(routes.setAndRun(FolderClass, function(model, req) {
+			return model.sortFolders(req.params.projectid, req.params.parentid, req.body);
+	}));
+
 };
 


### PR DESCRIPTION
This modal dialog allows users to set the default sort order for a folder. They can say the default is sort by Name or Date (asc or desc) and they can apply this setting to all subfolders.  Or they can elect to custom sort the folder's content using drag and drop.

The drag and drop collections are disabled if the sorting option is anything but custom.
Selecting items is only enabled if custom is selected.
If any number of, say, folder objects are selected and the user clicks on a document all the folders are unselected.
If custom is selected and some items are selected these items are de-selected when the user changes the sorting option away from custom.

If the user changes the sorting option away from custom they are first given a confirmation dialog. If they select cancel they keep the custom sort order. If they select to proceed with the change the folder and document lists are immediately sorted based on the selected sort option (this is nearly instant as the sorting is done entirely on the client side).

If the sort option was any of the Name or Date choices the "Apply to children" checkbox label reflects the sorting choice. For example "Apply name ascending to all subfolders". This clearly informs the user as to what action this checkbox will invoke when they Save.

If the user selects custom and the "Apply to subfolders" option was checked then the code un-checks the "Apply to subfolders" option.
While the Custom option is selected the "Apply to subfolders" option is disabled and it's label is disabled.

When Custom is active and the user starts a drag operation on one of the lists, say folders, then the other list's drag and drop is disabled. (Otherwise the user could drop a folder into documents or visa versa.)

Initialization of the UI is based on the saved sorting options for the folder. Includes set the sorting option controls based on the incoming setting and includes disabling the Apply to Subfolders if custom is selected or update the label of the Apply control based on the Name/Date selection.  Of course, sort the lists by the sorting option.

On Save, if the Apply to Subfolders option is checked then confirm the action with the user. If they cancel return to the UI. Otherwise:
* save the sorting options for the folder
* apply to all children if checked.
* if custom sorting then update the sort order of all folders and documents

Note the "apply to all subfolders" is not saved to the database; just the effect is that all subfolders have default sort option set.

Also note that as new documents and folders are added they always will be at the end of custom sort lists.

When custom sorting is select the UI shows move icons to indicate the drag and drop is active.

If custom sorting ask user before cancelling to confirm. Prevent background click or ESC to trigger cancel.

Add spinner when busy

EPIC code use document upload date rather than documentDate used by MEM
hide debug