### PR TITLE
Collections UI Clean-up

### DIFF
--- a/modules/collections/client/scss/collections.scss
+++ b/modules/collections/client/scss/collections.scss
@@ -1,117 +1,101 @@
-
-.collections-view {
+.edit-collection-form {
     section {
-        margin-bottom: 3rem;
-
-        h2 {
-            font-size: 2rem;
-        }
-    }
-
-    .main-doc-section {
-        .ng-table-pager {
-            display: none;
-        }
+        padding: 0;
+        border: none;
     }
 }
 
-.collections-edit {
-    section {
-        margin-bottom: 3rem;
-
-        h2 {
-            font-size: 2rem;
-        }
+.collection-table {
+    .date-col {
+        width: 13rem;
     }
 
-    .main-doc-section {
-        .ng-table-pager {
-            display: none;
+    .status-col {
+        width: 12rem;
+    }
+}
+
+@media (min-width: 1200px) {
+    .collection-table {
+        .date-col {
+            width: 17%;
+        }
+
+        .status-col {
+            width: 12%;
         }
     }
 }
 
-/**
- * An element with .dndPlaceholder class will be
- * added to the dnd-list while the user is dragging
- * over it.
- */
-
-
-.collection-header {
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
-    display: block;
-    margin-bottom: -1px;
-    padding: 10px 15px;
+.collection-docs {
+    .ng-table-pager {
+        display: none;
+    }
 }
 
-.sort-icon:hover {
-    background: #fff;
+.collection-document-table {
+    td {
+        vertical-align: top !important;
+    }
+
+    .date-col {
+        width: 13rem;
+    }
+    .date-uploaded-col {
+        width: 14rem;
+    }
+
+    .status-col {
+        width: 12rem;
+    }
 }
 
-.sort-icon {
-    display: inline-block;
-    margin-top: -2px;
-    margin-left: 0.25rem;
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 5px 5px 0 5px;
-    border-color: #494949 transparent transparent transparent;
-    vertical-align: middle;
-}
+@media (min-width: 1200px) {
+    .collection-document-table {
+        .date-col {
+            width: 17%;
+        }
+        .date-uploaded-col {
+            width: 17%;
+        }
 
-.sort-icon-descending {
-    border-width: 0 5px 5px 5px;
-    border-color: transparent transparent #494949 transparent;
+        .status-col {
+            width: 12%;
+        }
+    }
 }
 
 .collection-document {
     display: flex;
     flex-flow: row wrap;
     justify-content: flex-start;
-}
 
-.collection-document .rank {
-    flex: 0 0 2rem;
-}
+    .date {
+        flex: 0 1 10%;
+    }
+    
+    .name {
+        flex: 1 1 20%;
+    }
 
-.collection-document .name {
-    flex: 1 1 20%;
-}
-
-.collection-document .date {
-    flex: 0 1 10%;
-}
-.collection-document .status {
-    flex: 0 1 8%;
-}
-.collection-document .actions {
-    flex: 0 1 5%;
+    .status {
+        flex: 0 1 8%; 
+    }
 }
 
 @media (min-width: 768px) {
-    .collection-document .name {
-        flex: 1 1 20rem;
-    }
-
-    .collection-document .date {
-        flex: 0 1 15rem;
-    }
-    .collection-document .status {
-        flex: 0 1 15rem;
-    }
-    .collection-document .actions {
-        flex: 0 1 2rem;
-    }
-}
-
-@media (max-width: 480px) {
     .collection-document {
-        flex-direction: column;
+        .date {
+            flex: 0 1 15rem;
+        }
+        
+        .name {
+            flex: 1 1 20rem;  
+        }
+
+        .status {
+            flex: 0 1 15rem;
+        }
     }
 }
 

--- a/modules/collections/client/views/collection-edit.html
+++ b/modules/collections/client/views/collection-edit.html
@@ -1,131 +1,151 @@
-<form class="view-form" name="collectionForm" ng-submit="save(collectionForm.$valid)" novalidate>
+<form class="view-form edit-collection-form" name="collectionForm" ng-submit="save(collectionForm.$valid)" novalidate>
 
-  <div class="view-title-container flex-row">
-    <h1 ng-if="collection.addedBy">Edit Collection</h1>
-    <h1 ng-if="!collection.addedBy">Add Collection</h1>
-    <div class="actions">
-      <button class="btn btn-default btn-sm" ng-if="!collection.addedBy" ui-sref="p.collection.list">Cancel</button>
-      <button class="btn btn-default btn-sm" ng-if="collection.addedBy" ng-click="goToDetail()">Cancel</button>
-      <button class="btn btn-success btn-sm" ng-if="collection.addedBy && !collection.isPublished" ng-click="publish()" type="button"><span class="glyphicon glyphicon-ok"></span><span>Publish</span></button>
-      <button class="btn btn-default btn-sm" ng-if="collection.addedBy && collection.isPublished" ng-click="unpublish()" type="button"><span class="glyphicon glyphicon-ban-circle"></span><span>Unpublish</span></button>
-      <button class="btn btn-danger btn-sm" ng-if="collection.addedBy" ng-click="delete()" type="button"><span class="glyphicon glyphicon-trash"></span><span>Delete</span></button>
-      <button class="btn btn-primary btn-sm" type="submit">Save</button>
+    <div class="view-title-container flex-row">
+        <h1 ng-if="collection.addedBy">Edit Collection</h1>
+        <h1 ng-if="!collection.addedBy">Add Collection</h1>
+        <div class="actions">
+            <button class="btn btn-default btn-sm" 
+                ng-if="!collection.addedBy" ui-sref="p.collection.list">
+                Cancel
+            </button>
+            <button class="btn btn-default btn-sm" 
+                ng-if="collection.addedBy" ng-click="goToDetail()">
+                Cancel
+            </button>
+            <button class="btn btn-default btn-sm" 
+                ng-if="collection.addedBy && !collection.isPublished" ng-click="publish()" type="button">
+                <span class="glyphicon glyphicon-ok-circle"></span><span>Publish</span>
+            </button>
+            <button class="btn btn-default btn-sm" 
+                ng-if="collection.addedBy && collection.isPublished" ng-click="unpublish()" type="button">
+                <span class="glyphicon glyphicon-ban-circle"></span><span>Unpublish</span>
+            </button>
+            <button class="btn btn-primary btn-sm" type="submit">
+                Save
+            </button>
+            <button class="btn btn-default btn-sm" 
+                ng-if="collection.addedBy" ng-click="delete()" type="button">
+                <span class="glyphicon glyphicon-trash"></span><span>Delete</span>
+            </button>
+        </div>
     </div>
-  </div>
 
-  <div class="view-body-container">
-    <div class="row">
-      <div class="col-md-3">
-        <div class="form-group" x-show-errors>
-          <label for="displayName" class="control-label">Name</label>
-          <input id="displayName" name="displayName" ng-model='collection.displayName' class="form-control" required>
-          <div ng-messages="collectionForm.displayName.$error" role="alert">
-            <p class="help-block error-text" ng-message="required">Name is required.</p>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-3">
-        <div class="form-group">
-          <label for="type" class="control-label">Type</label>
-          <select id="type" ng-model='collection.type' class="form-control" ng-options="t.id as t.title for t in types"></select>
-        </div>
-      </div>
-      <div class="col-md-3">
-        <div class="form-group" x-show-errors>
-          <label for="date" class="control-label">Date</label>
-          <div class="form-control date-picker" name="date" title="{{ collection.date | amDateFormat:'HH:mm:ss' }}"
-            x-modal-date-picker x-selected-date="collection.date" x-header="'Choose a Date'">
-            <span ng-if="!collection.date">None</span>
-            {{ collection.date | amDateFormat:'ddd, MMM DD, YYYY' }}
-            <span class="glyphicon glyphicon-calendar"></span>
-          </div>
-          <div ng-messages="collectionForm.date.$error" role="alert">
-            <p class="help-block error-text" ng-message="required">Date is required.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-12">
-        <div class="form-group">
-          <label for="description" class="control-label">Description</label>
-          <textarea id="description" name="description" type="text" class="form-control" ng-model="collection.description" rows=3></textarea>
-        </div>
-      </div>
-    </div>
-    <div ng-if="collection.addedBy">
-        <section class="main-doc-section">
+    <div class="view-body-container">
+        <section>
             <div class="row">
-                <div class="col-sm-12">
-                    <h2>Main Document</h2>
-                    <div class="button-bar">
-                        <button class="btn btn-default btn-sm" title="Link Main Document"
-                            x-document-mgr-link-modal x-project="project"
-                            x-target="linkedMainDocument"
-                            x-target-name="collection.displayName"
-                            x-on-ok="updateMainDocument"><span class="glyphicon glyphicon-link"></span><span>Link Main Document</span>
-                        </button>
+                <div class="col-md-3">
+                    <div class="form-group" x-show-errors>
+                        <label class="control-label" for="displayName">Name</label>
+                        <input class="form-control" id="displayName" name="displayName" ng-model='collection.displayName' required>
+                        <div ng-messages="collectionForm.displayName.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Name is required.</p>
+                        </div>
                     </div>
-                    <div class="table-container">
-                        <table class="table" ng-table="mainTableParams">
-                            <tr ng-repeat="d in $data" ng-click="goToDocument(d.document)">
-                                <td data-title="'Name'" title: 'Name'>{{ d.document.displayName | removeExtension }}</td>
-                                <td data-title="'Date'" title: 'Date'>{{ d.document.documentDate | amDateFormat:'MMMM DD, YYYY' }}</td>
-                                <td data-title="'Uploaded'" title: 'Uploaded'>{{ d.document.dateUploaded | amDateFormat:'MMMM DD, YYYY' }}</td>
-                                <td class="actions-col" header-class="'actions-col x1'">
-                                    <a class="btn icon-btn" title="Remove Main Document" ng-click="removeMainDocument(d.document)">
-                                        <span class="glyphicon glyphicon-trash"></span>
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr class="no-results" ng-if="!$data || $data.length === 0">
-                                <td colspan="4">No document found.</td>
-                            </tr>
-                        </table>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group">
+                        <label class="control-label" for="type">Type</label>
+                        <select class="form-control" id="type" ng-model='collection.type' ng-options="t.id as t.title for t in types"></select>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="form-group" x-show-errors>
+                        <label for="date" class="control-label">Date</label>
+                        <div class="form-control date-picker" name="date" x-modal-date-picker
+                            x-selected-date="collection.date" x-header="'Choose a Date'">
+                            <span ng-if="!collection.date">None</span> {{ collection.date | amDateFormat:'YYYY-MM-DD'}}
+                            <span class="glyphicon glyphicon-calendar"></span>
+                        </div>
+                        <div ng-messages="collectionForm.date.$error" role="alert">
+                            <p class="help-block error-text" ng-message="required">Date is required.</p>
+                        </div>
                     </div>
                 </div>
             </div>
-        </section>
-        <section>
             <div class="row">
                 <div class="col-sm-12">
-                    <h2>Other Documents</h2>
+                    <label class="control-label" for="description">Description</label>
+                    <textarea class="form-control" id="description" name="description" rows="3" ng-model="collection.description"></textarea>
+                </div>
+            </div>
+        </section>
+
+        <section ng-if="collection.addedBy">
+            <section>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <h2>Main Document</h2>
                         <div class="button-bar">
-                            <button class="btn btn-default btn-sm" title="Link Other Documents"
-                                x-document-mgr-link-modal x-project="project"
-                                x-target="linkedOtherDocuments"
-                                x-target-name="collection.displayName"
-                                x-on-ok="updateOtherDocuments"><span class="glyphicon glyphicon-link"></span><span>Link Other Documents</span>
-                            </button>
-                            <button class="btn btn-default btn-sm"
-                                    title="Reorder"
-                                    x-reorder-collection-modal x-collection="collection" x-on-save="otherDocsReordered">
-                                <span class="glyphicon glyphicon-sort"></span>
-                                <span>Reorder</span>
+                            <button class="btn btn-default btn-sm" title="Link main document to this collection" x-document-mgr-link-modal x-project="project" x-target="linkedMainDocument"
+                                x-target-name="collection.displayName" x-on-ok="updateMainDocument"><span class="glyphicon glyphicon-link"></span><span>Link Main Document</span>
                             </button>
                         </div>
-                        <div class="table-container">
-                            <table class="table" ng-table="otherTableParams">
-                                <tr ng-repeat="d in $data" ng-click="goToDocument(d.document)">
-                                    <td data-title="'Sort'" ng-show="false" title='Sort' sortable="'Sort'">{{ d.document.sortOrder}}</td>
-                                    <td data-title="'Name'" title='Name' sortable="'Name'">{{ d.document.displayName | removeExtension }}</td>
-                                    <td data-title="'Date'" title='Date' sortable="'Date'">{{ d.document.documentDate | amDateFormat:'MMMM DD, YYYY' }}</td>
-                                    <td data-title="'Uploaded'" title='Uploaded' sortable="'Uploaded'">{{ d.document.dateUploaded | amDateFormat:'MMMM DD, YYYY' }}</td>
+                        <div class="table-container collection-docs">
+                            <table class="table collection-document-table" ng-table="mainTableParams">
+                                <tr ng-repeat="d in $data">
+                                    <td header-class="'name-col'" data-title="'Name'" title: 'Name'>{{ d.document.displayName | removeExtension }}</td>
+                                    <td header-class="'date-col'"  data-title="'Document Date'" title: 'Date'>{{ d.document.documentDate | amDateFormat:'YYYY-MM-DD' }}</td>
+                                    <td header-class="'date-uploaded-col'" data-title="'Date Uploaded'" title: 'Uploaded'>{{ d.document.dateUploaded | amDateFormat:'YYYY-MM-DD' }}</td>
+                                    <td header-class="'status-col'" data-title="'Status'" title: 'Uploaded'>
+                                        <span class="label label-success" ng-if="d.document.isPublished == true">PUBLISHED</span>
+                                        <span class="label label-unpublished" ng-if="d.document.isPublished == false">UNPUBLISHED</span>
+                                    </td>
                                     <td class="actions-col" header-class="'actions-col x1'">
-                                        <a class="btn icon-btn" title="Remove Other Document" ng-click="removeOtherDocument(d.document)">
+                                        <a class="btn icon-btn" title="Remove document from this collection" ng-click="removeMainDocument(d.document)">
                                             <span class="glyphicon glyphicon-trash"></span>
                                         </a>
                                     </td>
                                 </tr>
                                 <tr class="no-results" ng-if="!$data || $data.length === 0">
-                                    <td colspan="4">No documents found.</td>
+                                    <td colspan="5">No document found.</td>
                                 </tr>
                             </table>
                         </div>
                     </div>
                 </div>
-            </div>
+            </section>
+            <section>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <h2>Other Documents</h2>
+                        <div class="button-bar">
+                            <button class="btn btn-default btn-sm" title="Link other documents to this collection" x-document-mgr-link-modal x-project="project" x-target="linkedOtherDocuments"
+                                x-target-name="collection.displayName" x-on-ok="updateOtherDocuments"><span class="glyphicon glyphicon-link"></span><span>Link Other Documents</span>
+                            </button>
+                            <button class="btn btn-default btn-sm" 
+                                title="Set the default order documents will be displayed" 
+                                x-reorder-collection-modal x-collection="collection" 
+                                x-on-save="otherDocsReordered">
+                                <span class="glyphicon glyphicon-sort"></span>
+                                <span>Set Document Order</span>
+                            </button>
+                        </div>
+                        <div class="table-container collection-docs">
+                            <table class="table collection-document-table" ng-table="otherTableParams">
+                                <tr ng-repeat="d in $data">
+                                    <td header-class="'name-col'" data-title="'Name'" sortable="'Name'">{{ d.document.displayName | removeExtension }}</td>
+                                    <td header-class="'date-col'" data-title="'Document Date'" sortable="'Date'">{{ d.document.documentDate | amDateFormat:'YYYY-MM-DD' }}</td>
+                                    <td header-class="'date-uploaded-col'" data-title="'Date Uploaded'" sortable="'Uploaded'">{{ d.document.dateUploaded | amDateFormat:'YYYY-MM-DD' }}</td>
+                                    <td header-class="'status-col'" data-title="'Status'" title: 'Uploaded'>
+                                        <span class="label label-success" ng-if="d.document.isPublished == true">PUBLISHED</span>
+                                        <span class="label label-unpublished" ng-if="d.document.isPublished == false">UNPUBLISHED</span>
+                                    </td>
+                                    <td class="actions-col" header-class="'actions-col x1'">
+                                        <a class="btn icon-btn" title="Remove document from this collection" ng-click="removeOtherDocument(d.document)">
+                                            <span class="glyphicon glyphicon-trash"></span>
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr class="no-results" ng-if="!$data || $data.length === 0">
+                                    <td colspan="5">No documents found.</td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </section>
+
     </div>
-  </div>
+
 </form>

--- a/modules/collections/client/views/collection-view.html
+++ b/modules/collections/client/views/collection-view.html
@@ -1,11 +1,24 @@
 <div class="view-title-container flex-row">
     <h1>{{ collection.displayName }}</h1>
     <div class="actions">
-        <button class="btn btn-default btn-sm" ui-sref="p.collection.list">Cancel</button>
-        <button class="btn btn-success btn-sm" ng-if="collection.addedBy && !collection.isPublished" ng-click="publish()" type="button"><span class="glyphicon glyphicon-ok"></span><span>Publish</span></button>
-        <button class="btn btn-warning btn-sm" ng-if="collection.addedBy && collection.isPublished" ng-click="unpublish()" type="button"><span>Unpublish</span></button>
-        <button class="btn btn-danger btn-sm" ng-if="collection.addedBy" ng-click="delete()" type="button"><span class="glyphicon glyphicon-trash"></span><span>Delete</span></button>
-        <button class="btn btn-default btn-sm" ui-sref="p.collection.edit({ collectionId:collection._id })" type="button">Edit</button>
+        <button class="btn btn-default btn-sm" ui-sref="p.collection.list">
+            Cancel
+        </button>
+        <button class="btn btn-default btn-sm" 
+            ng-if="collection.addedBy && !collection.isPublished" ng-click="publish()" type="button">
+            <span class="glyphicon glyphicon-ok-circle"></span><span>Publish</span>
+        </button>
+        <button class="btn btn-default btn-sm" 
+            ng-if="collection.addedBy && collection.isPublished" ng-click="unpublish()" type="button">
+            <span class="glyphicon glyphicon-ban-circle"></span><span>Unpublish</span>
+        </button>
+        <button class="btn btn-default btn-sm" ui-sref="p.collection.edit({ collectionId:collection._id })" type="button">
+            Edit
+        </button>
+        <button class="btn btn-default btn-sm" 
+            ng-if="collection.addedBy" ng-click="delete()" type="button">
+            <span class="glyphicon glyphicon-trash"></span><span>Delete</span>
+        </button>
     </div>
 </div>
 
@@ -14,50 +27,51 @@
         <div class="row">
             <div class="col-md-3">
                 <div class="form-group">
-                    <label for="displayName" class="control-label">Name</label>
-                    <p class="form-control-static">{{ collection.displayName }}</p>
+                    <label class="control-label" for="displayName">Name</label>
+                    <input class="form-control" type="text" value="{{ collection.displayName }}" readonly>
                 </div>
             </div>
             <div class="col-md-3">
                 <div class="form-group">
-                    <label for="type" class="control-label">Type</label>
-                    <p class="form-control-static">{{ collection.type }}</p>
+                    <label class="control-label" for="type">Type</label>
+                    <input class="form-control" type="text" value="{{ collection.type }}" readonly>
                 </div>
             </div>
             <div class="col-md-3">
                 <div class="form-group">
-                    <label for="date" class="control-label">Date</label>
-                    <p class="form-control-static">{{ collection.date | amDateFormat:'MMMM DD, YYYY' }}</p>
+                    <label class="control-label" for="date">Date</label>
+                    <input class="form-control date-picker" type="text" value="{{ collection.date | amDateFormat:'YYYY-MM-DD' }}" readonly>
                 </div>
             </div>
         </div>
         <div class="row">
             <div class="col-sm-12">
-                <label for="description" class="control-label">Description</label>
-                <p class="form-control-static">{{ collection.description }}</p>
+                <label class="control-label" for="description">Description</label>
+                <textarea class="form-control" rows="3" readonly>{{ collection.description }}</textarea>
             </div>
         </div>
     </section>
-    <section class="main-doc-section">
+
+    <section>
         <div class="row">
             <div class="col-sm-12">
                 <h2>Main Document</h2>
                 <div class="button-bar">
-                    <button class="btn btn-default btn-sm" title="Link Main Document"
+                    <button class="btn btn-default btn-sm" title="Link main document to this collection"
                         x-document-mgr-link-modal x-project="project"
                         x-target="linkedMainDocument"
                         x-target-name="collection.displayName"
                         x-on-ok="updateMainDocument"><span class="glyphicon glyphicon-link"></span><span>Link Main Document</span>
                     </button>
                 </div>
-                <div class="table-container">
-                    <table class="table" ng-table="mainTableParams">
-                        <tr ng-repeat="d in $data" ng-click="goToDocument(d.document)">
-                            <td data-title="'Name'" title: 'Name'>{{ d.document.displayName | removeExtension }}</td>
-                            <td data-title="'Date'" title: 'Date'>{{ d.document.documentDate | amDateFormat:'MMMM DD, YYYY' }}</td>
-                            <td data-title="'Uploaded'" title: 'Uploaded'>{{ d.document.dateUploaded | amDateFormat:'MMMM DD, YYYY' }}</td>
+                <div class="table-container collection-docs">
+                    <table class="table collection-document-table" ng-table="mainTableParams">
+                        <tr ng-repeat="d in $data">
+                            <td header-class="'name-col'" data-title="'Name'">{{ d.document.displayName | removeExtension }}</td>
+                            <td header-class="'date-col'" data-title="'Document Date'">{{ d.document.documentDate }}</td>
+                            <td header-class="'date-uploaded-col'" data-title="'Date Uploaded'">{{ d.document.dateUploaded | amDateFormat:'YYYY-MM-DD' }}</td>
                             <td class="actions-col" header-class="'actions-col x1'">
-                                <a class="btn icon-btn" title="Remove Main Document" ng-click="removeMainDocument(d.document)">
+                                <a class="btn icon-btn" title="Remove document from this collection" ng-click="removeMainDocument(d.document)">
                                     <span class="glyphicon glyphicon-trash"></span>
                                 </a>
                             </td>
@@ -70,31 +84,34 @@
             </div>
         </div>
     </section>
+
     <section>
         <div class="row">
             <div class="col-sm-12">
                 <h2>Other Documents</h2>
                     <div class="button-bar">
-                        <button class="btn btn-default btn-sm" title="Link Other Documents"
+                        <button class="btn btn-default btn-sm" title="Link other documents to this collection"
                             x-document-mgr-link-modal x-project="project"
                             x-target="linkedOtherDocuments"
                             x-target-name="collection.displayName"
                             x-on-ok="updateOtherDocuments"><span class="glyphicon glyphicon-link"></span><span>Link Other Documents</span>
                         </button>
                         <button class="btn btn-default btn-sm"
-                                title="Reorder"
-                                x-reorder-collection-modal x-collection="collection" x-on-save="otherDocsReordered">
+                            title="Set the default order documents will be displayed"
+                            x-reorder-collection-modal x-collection="collection" 
+                            x-on-save="otherDocsReordered">
                             <span class="glyphicon glyphicon-sort"></span>
-                            <span>Reorder</span>
+                            <span>Set Document Order</span>
                         </button>
                     </div>
-                    <div class="table-container">
-                        <table class="table" ng-table="otherTableParams">
-                            <tr ng-repeat="d in $data" ng-click="goToDocument(d.document)">
-                                <td data-title="'Name'" title='Name' sortable="'Name'">{{ d.document.displayName | removeExtension }}</td>
-                                <td data-title="'Date'" title='Date' sortable="'Date'">{{ d.document.documentDate | amDateFormat:'MMMM DD, YYYY' }}</td>
+                    <div class="table-container collection-docs">
+                        <table class="table collection-document-table" ng-table="otherTableParams">
+                            <tr ng-repeat="d in $data">
+                                <td header-class="'name-col'" data-title="'Name'" sortable="'Name'">{{ d.document.displayName | removeExtension }}</td>
+                                <td header-class="'date-col'" data-title="'Document Date'" sortable="'Document Date'">{{ d.document.documentDate }}</td>
+                                <td header-class="'date-uploaded-col'" data-title="'Date Uploaded'" sortable="'Uploaded'">{{ d.document.dateUploaded | amDateFormat:'YYYY-MM-DD' }}</td>
                                 <td class="actions-col" header-class="'actions-col x1'">
-                                    <a class="btn icon-btn" title="Remove Other Document" ng-click="removeOtherDocument(d.document)">
+                                    <a class="btn icon-btn" title="Remove document from this collection" ng-click="removeOtherDocument(d.document)">
                                         <span class="glyphicon glyphicon-trash"></span>
                                     </a>
                                 </td>
@@ -108,4 +125,5 @@
             </div>
         </div>
     </section>
+
 </div>

--- a/modules/collections/client/views/collections-list.html
+++ b/modules/collections/client/views/collections-list.html
@@ -1,36 +1,34 @@
-
 <div class="view-title-container">
   <h1>Collections</h1>
 </div>
 
 <div class="view-body-container">
   <div class="button-bar">
-    <a class="btn btn-default btn-sm" ui-sref="p.collection.create()">
-      <span class="glyphicon glyphicon-plus"></span>
-      <span>Add Collection</span>
-    </a>
+      <a class="btn btn-default btn-sm" ui-sref="p.collection.create()">
+          <span class="glyphicon glyphicon-plus"></span><span>Add Collection</span>
+      </a>
   </div>
   <div class="table-container">
-    <table class="table table-hover" ng-table="tableParams" show-filter="true">
-      <tr ng-repeat="c in $data" ui-sref="p.collection.detail({ collectionId: c._id })">
-        <td data-title="'Name'"      title:'Name'      filter="{'displayName':'text'}" sortable="'displayName'">{{ c.displayName }}</td>
-        <td data-title="'Type'"      title:'Type'      filter="{'type':'select'}"      sortable="'type'"  filter-data="types">{{ c.type }}</td>
-        <td data-title="'Date'"      title:'Date'      filter="{'date':'text'}"        sortable="'date'">{{ c.date | amDateFormat:'MMMM DD, YYYY' }}</td>
-        <td data-title="'Status'" title:'Status' filter="{'isPublished':'text'}" sortable="'isPublished'">
-          <span class="label label-success" ng-if="c.isPublished">PUBLISHED</span>
-          <span class="label label-default" ng-if="!c.isPublished">UNPUBLISHED</span>
-        </td>
-        <td class="actions-col x1" header-class="'actions-col x1'">
-          <a class="btn icon-btn" ng-click="$event.stopPropagation()" ui-sref="p.collection.edit({ collectionId: c._id })">
-            <span class="glyphicon glyphicon-pencil"></span>
-          </a>
-        </td>
-      </tr>
-      <tr ng-if="!$data || $data.length === 0">
-        <td colspan="5">
-          No collections found.
-        </td>
-      </tr>
-    </table>
+      <table class="table table-hover collection-table" ng-table="tableParams" show-filter="true">
+          <tr ng-repeat="c in $data" ui-sref="p.collection.detail({ collectionId: c._id })">
+              <td data-title="'Name'" title: 'Name' filter="{'displayName':'text'}" sortable="'displayName'">{{ c.displayName }}</td>
+              <td data-title="'Type'" title: 'Type' filter="{'type':'select'}" sortable="'type'" filter-data="types">{{ c.type }}</td>
+              <td header-class="'date-col'" data-title="'Date'" filter="{'date':'text'}" sortable="'date'">{{ c.date | amDateFormat:'YYYY-MM-DD' }}</td>
+              <td header-class="'status-col'" data-title="'Status'" filter="{'isPublished':'text'}" sortable="'isPublished'">
+                  <span class="label label-success" ng-if="c.isPublished">PUBLISHED</span>
+                  <span class="label label-unpublished" ng-if="!c.isPublished">UNPUBLISHED</span>
+              </td>
+              <td class="actions-col x1" header-class="'actions-col x1'">
+                  <a class="btn icon-btn" ng-click="$event.stopPropagation()" ui-sref="p.collection.edit({ collectionId: c._id })">
+                      <span class="glyphicon glyphicon-pencil"></span>
+                  </a>
+              </td>
+          </tr>
+          <tr ng-if="!$data || $data.length === 0">
+              <td colspan="5">
+                  No collections found.
+              </td>
+          </tr>
+      </table>
   </div>
 </div>

--- a/modules/collections/client/views/modal-collections-reorder.html
+++ b/modules/collections/client/views/modal-collections-reorder.html
@@ -1,7 +1,7 @@
 
 <div class="modal-header">
     <button class="btn btn-default close" ng-click="vmm.cancel()"><span aria-hidden="true">×</span></button>
-    <h3 class="modal-title">Select and drag files to re-order</h3>
+    <h3 class="modal-title">Set Document Order</h3>
 </div>
 
 <div class="modal-body">

--- a/modules/core/client/scss/components/forms.scss
+++ b/modules/core/client/scss/components/forms.scss
@@ -1,4 +1,127 @@
+form {
+	section {
+		margin-bottom: 2rem;
+		padding-bottom: 1rem;
+		border-bottom: 1px solid #DDD;
+	}
+	
+	.help-block {
+		margin-top: 0.5rem;
+		margin-bottom: 0;
+		font-size: 1.2rem;
+	}
+}
 
 textarea {
 	resize: vertical;
+}
+
+.form-container {
+	padding: 0 2rem;
+}
+
+.form-group {
+	margin-bottom: 2rem;
+
+	&.no-margin {
+		margin-bottom: 0;
+	}
+}
+
+.form-control[readonly] {
+	box-shadow: none;
+
+	&:active,
+	&:focus {
+		border-color: #ccc;
+		box-shadow: none;
+		outline: none;
+	}
+}
+
+.form-control-static {
+	padding: 6px 12px;
+	background: #EEE;
+	border: 1px solid #DDD;
+	border-radius: 4px;
+}
+
+.form-validation-msg {
+	margin-left: 0.25rem;
+	font-size: 1.2rem;
+	font-weight: normal;
+	color: #999;
+}
+
+.control-label {
+	em {
+		@extend .form-validation-msg;
+	}
+
+	em.required {
+		display: none;
+	}
+}
+
+.checkbox-row {
+	margin-top: 0.6rem;
+
+	label {
+		font-weight: normal;
+	}
+}
+
+.checkbox,
+.checkbox-inline {
+	margin-right: 2rem;
+	
+	input {
+		margin-top: 2px;
+	}
+}
+
+.date-picker {
+	position: relative;
+	padding-right: 4rem;
+	min-width: 17rem;
+	max-width: 17rem;
+
+	strong {
+		margin-right: 1.5rem;
+	}
+
+	.glyphicon {
+		position: absolute;
+		top: 0.8rem;
+		right: 1rem;
+		font-size: 1.6rem;
+	}
+}
+
+.date-range-control {
+	.spacer {
+		padding: 0 1rem;
+		line-height: 3.4rem;
+	}
+}
+
+.input-group.date-range {
+	width: 16rem;
+}
+
+.radio-group {
+	padding-top: 0.7rem;
+	
+	input[type="radio"] {
+		margin-top: 2px;
+	}
+}
+
+.has-error {
+	.control-label {
+		em.required {
+			display: inline;
+			color: $danger-text;
+		}
+	}
 }

--- a/modules/core/client/scss/core.scss
+++ b/modules/core/client/scss/core.scss
@@ -2135,45 +2135,6 @@ $sidenav-text-shadow: 0 0 2px #FFF;
 }
 
 
-/* DATE PICKER
-Implementing this as a stop-gap solution to a proper control.
------------------------------- */
-.date-picker {
-	min-width: 17rem;
-	max-width: 17rem;
-	position: relative;
-	padding-top: 0.8rem;
-	padding-right: 4rem;
-	font-size: 1.3rem;
-	cursor: pointer;
-
-	strong {
-		margin-right: 1.5rem;
-	}
-
-	.glyphicon {
-		position: absolute;
-		top: 0.8rem;
-		right: 1rem;
-		font-size: 1.6rem;
-	}
-}
-
-
-/* DATE RANGE CONTROL
------------------------------- */
-.date-range-control {
-	.spacer {
-		padding: 0 1rem;
-		line-height: 3.4rem;
-	}
-}
-
-.input-group.date-range {
-	width: 16rem;
-}
-
-
 /* DROPDOWN CARET
 ------------------------------ */
 .caret-up {
@@ -2381,109 +2342,6 @@ $file-browser-item-active: #2b5580;
 
 .has-error .mce-tinymce {
 	border: 1px solid red;
-}
-
-
-/* FORM CONTROLS
------------------------------- */
-form {
-	section {
-		margin-bottom: 2rem;
-		padding-bottom: 1rem;
-		border-bottom: 1px solid #DDD;
-	}
-
-	.help-block {
-		margin-top: 0.5rem;
-		margin-bottom: 0;
-		font-size: 1.2rem;
-	}
-}
-
-.form-container {
-	padding: 0 2rem;
-}
-
-.form-group {
-	margin-bottom: 2rem;
-
-	&.no-margin {
-		margin-bottom: 0;
-	}
-}
-
-.form-validation-msg {
-	margin-left: 0.25rem;
-	font-size: 1.2rem;
-	font-weight: normal;
-	color: #999;
-}
-
-.form-control-static {
-	padding: 6px 8px;
-	background: #EEE;
-	border: 1px solid #DDD;
-	border-radius: 4px;
-}
-
-.checkbox-row {
-	margin-top: 0.6rem;
-
-	label {
-		font-weight: normal;
-	}
-}
-
-.checkbox,
-.checkbox-inline {
-	margin-right: 2rem;
-
-	input {
-		margin-top: 2px;
-	}
-}
-
-.control-label {
-	em {
-		@extend .form-validation-msg;
-	}
-
-	em.required {
-		display: none;
-	}
-}
-
-.radio-group {
-	padding-top: 0.7rem;
-
-	label {
-		margin-bottom: 0.5rem;
-
-		&:last-child {
-			margin-bottom: 0;
-		}
-
-		+ .help-block {
-			margin-top: -0.5rem;
-			margin-left: 2rem;
-		}
-	}
-
-	/* Fix - Myriad Pro causes an issue with the label offset so we fix it */
-	input[type="radio"] {
-		margin-top: -0.2rem;
-		margin-right: 0.5rem;
-		vertical-align: middle;
-	}
-}
-
-.has-error {
-	.control-label {
-		em.required {
-			display: inline;
-			color: $danger-text;
-		}
-	}
 }
 
 
@@ -2843,6 +2701,10 @@ section {
 		margin-bottom: 1rem;
 		font-size: 1.6rem;
 		font-weight: bold;
+	}
+
+	+ section {
+		margin-top: 3rem;
 	}
 }
 
@@ -4315,6 +4177,7 @@ tmpl-template-render {
 // COMPONENTS
 @import "modules/core/client/scss/components/accordion.scss";
 @import "modules/core/client/scss/components/file-browser.scss";
+@import "modules/core/client/scss/components/forms.scss";
 @import "modules/core/client/scss/components/panel.scss";
 @import "modules/core/client/scss/components/misc.scss";
 @import "modules/core/client/scss/components/pdf-viewer.scss";


### PR DESCRIPTION
Refactor and clean-up of the collections interface. 

- Standardized columns and naming conventions for main document and other document interfaces

Additional Fixes
- Refactored and removed unused selectors (SCSS)
- Added status columns to both main and other document interfaces
- Corrected incorrect usage of title tag on table cells
- Moved some of the form component styling from core.scss to forms.scss (now referenced in core.scss as a separate component)
- Updated the collections view to use true read-only inputs