### PR TITLE
[EPIC-1247] Fixing issue with long files names in Document Manager Interfaces

### DIFF
--- a/modules/core/client/scss/components/file-browser.scss
+++ b/modules/core/client/scss/components/file-browser.scss
@@ -455,7 +455,6 @@ a.icon-btn {
     .fb-list-item {
         @include flexbox();
         @include flex(1 1 auto);
-        @include userselect(none);
         position: relative;
 
         .avatar {
@@ -1061,19 +1060,6 @@ $fb-upload-target-border: 2px dashed #BBB;
 .fb-browser-modal {
     .fb-link-select-files {
         margin-bottom: 2rem;
-    }
-
-    .file-browser {
-        height: 40rem;
-    }
-
-    .linked-files-container {
-        max-height: 40rem;
-        overflow-y: auto;
-
-        .row-actions {
-            display: block;
-        }
     }
 }
 

--- a/modules/core/client/scss/core.scss
+++ b/modules/core/client/scss/core.scss
@@ -3995,6 +3995,8 @@ tmpl-template-render {
 @import "modules/codelists/client/scss/codelist.scss";
 @import "modules/collections/client/scss/collections.scss";
 @import "modules/documents/client/scss/document-manager.scss";
+@import "modules/documents/client/scss/document-manager-link.scss";
+@import "modules/documents/client/scss/document-manager-move.scss";
 @import "modules/communications/client/scss/communications.scss";
 @import "modules/invitations/client/scss/invitations.scss";
 @import "modules/projects/client/scss/project-schedule.scss";

--- a/modules/documents/client/directives/documents.manager.link.directive.js
+++ b/modules/documents/client/directives/documents.manager.link.directive.js
@@ -229,7 +229,6 @@ angular.module('documents')
 					$modal.open({
 						animation: true,
 						size: 'lg',
-						windowClass: 'fb-browser-modal',
 						templateUrl: 'modules/documents/client/views/document-manager-link-modal.html',
 						resolve: {},
 						controllerAs: 'linkModal',

--- a/modules/documents/client/directives/documents.manager.move.directive.js
+++ b/modules/documents/client/directives/documents.manager.move.directive.js
@@ -14,7 +14,6 @@ angular.module('documents')
 					$modal.open({
 						animation: true,
 						size: 'lg',
-						windowClass: 'fb-browser-modal',
 						templateUrl: 'modules/documents/client/views/document-manager-move.html',
 						resolve: {},
 						controllerAs: 'moveDlg',

--- a/modules/documents/client/scss/document-manager-link.scss
+++ b/modules/documents/client/scss/document-manager-link.scss
@@ -1,0 +1,48 @@
+.document-manager-link {
+    section {
+        + section {
+            margin-top: 2rem;
+        }
+    }
+
+    h4 {
+        margin-top: 0;
+        margin-bottom: 1rem;
+        font-size: 1.5rem;
+    }
+
+    .file-browser {
+        .folder-list {
+            .col {
+                &.name-col {
+                    .name {
+                        right: 10rem;
+                    }
+                }
+            }
+        }
+
+        .file-list {
+            .col {
+                &.name-col {
+                    .name {
+                        right: 5rem;
+                    }
+                }
+            }
+        }
+
+        .row-actions {
+            display: block;
+        }
+
+        &.select-files {
+            height: 40rem;
+        }
+
+        &.linked-files {
+            max-height: 40rem;
+            overflow-y: auto;
+        }
+    }
+}

--- a/modules/documents/client/scss/document-manager-move.scss
+++ b/modules/documents/client/scss/document-manager-move.scss
@@ -1,0 +1,5 @@
+.document-manager-move {
+    .file-browser {
+        height: 40rem;
+    }
+}

--- a/modules/documents/client/scss/document-manager.scss
+++ b/modules/documents/client/scss/document-manager.scss
@@ -1,6 +1,38 @@
 @import "modules/core/client/scss/global/mixins.scss";
 @import "modules/core/client/scss/global/helpers.scss";
 
+.document-manager {
+    position: relative;
+
+    .file-browser {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        bottom: 1rem;
+        left: 1rem;
+
+        .folder-list {
+            .col {
+                &.name-col {
+                    .name {
+                        right: 10rem;
+                    }
+                }
+            }
+        }
+
+        .file-list {
+            .col {
+                &.name-col {
+                    .name {
+                        right: 5rem;
+                    }
+                }
+            }
+        }
+    }
+}
+
 .doc-sort-order-modal {
     .modal-body {
         @include flexbox();

--- a/modules/documents/client/views/docs.html
+++ b/modules/documents/client/views/docs.html
@@ -13,6 +13,6 @@
 
 </div>
 
-<div class="view-body-container file-browser-container">
+<div class="view-body-container document-manager">
 	<x-document-mgr x-project="project" x-file="file" x-folder="folder"/>
 </div>

--- a/modules/documents/client/views/document-manager-link-modal.html
+++ b/modules/documents/client/views/document-manager-link-modal.html
@@ -6,7 +6,10 @@
 </div>
 
 <div class="modal-body">
-	<x-document-mgr-link x-project="project" x-linked-files="linkModal.linkedFiles" x-published-only="linkModal.publishedOnly">
+	<x-document-mgr-link class="document-manager-link" 
+		x-project="project" 
+		x-linked-files="linkModal.linkedFiles" 
+		x-published-only="linkModal.publishedOnly">
 </div>
 
 <div class="modal-footer clearfix">

--- a/modules/documents/client/views/document-manager-link.html
+++ b/modules/documents/client/views/document-manager-link.html
@@ -1,131 +1,113 @@
-
-<section class="fb-link-select-files">
-    <div class="file-browser">
-        <label>Select one or more files to link to this content</label>
-        <div class="fb-header">
-            <div class="fb-header-path">
-                <div class="fb-path"
-					ng-class="{'root':node.model.name == 'ROOT'}"
-					ng-repeat="node in documentMgr.currentPath">
-					<span class="fb-path-arrow" ng-if="node.model.name != 'ROOT'">&rsaquo;</span>
-					<button class="btn icon-btn" title="{{ node.model.name }}"
-						ng-click="documentMgr.selectNode(node.model.id)">
-						<i class="glyphicon glyphicon glyphicon-home" ng-if="node.model.name == 'ROOT'"></i>
-						<span class="btn-txt" ng-if="node.model.name != 'ROOT'">{{ node.model.name }}</span>
-					</button>
-				</div>
+<section class="file-browser select-files">
+    <h4>Select one or more files to link to this content</h4>
+    <div class="fb-header">
+        <div class="fb-header-path">
+            <div class="fb-path"
+                ng-class="{'root':node.model.name == 'ROOT'}"
+                ng-repeat="node in documentMgr.currentPath">
+                <span class="fb-path-arrow" ng-if="node.model.name != 'ROOT'">&rsaquo;</span>
+                <button class="btn icon-btn" title="{{ node.model.name }}"
+                    ng-click="documentMgr.selectNode(node.model.id)">
+                    <i class="glyphicon glyphicon glyphicon-home" ng-if="node.model.name == 'ROOT'"></i>
+                    <span class="btn-txt" ng-if="node.model.name != 'ROOT'">{{ node.model.name }}</span>
+                </button>
             </div>
         </div>
-
-        <div id="fbBody" class="fb-body" ng-class="{'panel-open': documentMgr.infoPanel.open}">
-
-            <div class="fb-list">
-
-                <!-- Load the File/Folder Directory -->
-                <!-- TODO: Remove 'hidden' selector when complete -->
-                <div class="spinner-container" ng-show="documentMgr.busy">
-			        <div class="spinner-new rotating"></div>
-                </div>
-
-                <!-- Column Header -->
-                <div class="column-header">
-                    <span class="col checkbox-col" ng-if="authentication.user">
-                        <input id="select-all" type="checkbox" title="Select All / None" ng-model="documentMgr.allChecked" ng-click="documentMgr.linkAll()"/>
-                        <label for="select-all">
-                            <span class="glyphicon glyphicon-ok"></span>
-                        </label>
-                    </span>
-
-                    <div class="fb-col-group">
-                        <div class="col name-col first-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('name')">
-                            <span>Name</span>
-                            <span class="sort-icon" ng-show="documentMgr.sorting.column === 'name'"></span>
-                        </div>
-                        <div class="col date-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('date')">
-                            <span>Uploaded</span>
-                            <span class="sort-icon" ng-show="documentMgr.sorting.column === 'date'"></span>
-                        </div>
-                        <div class="col size-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('size')">
-                            <span>Size</span>
-                            <span class="sort-icon" ng-show="documentMgr.sorting.column === 'size'"></span>
-                        </div>
-
-                        <div class="col status-col last-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('pub')" ng-if="authentication.user && publishedOnly !== 'true'">
-                            <span>Status</span>
-                            <span class="sort-icon" ng-show="documentMgr.sorting.column === 'pub'"></span>
-                        </div>
+    </div>
+    <div id="fbBody" class="fb-body" ng-class="{'panel-open': documentMgr.infoPanel.open}">
+        <div class="fb-list">
+            <div class="spinner-container" ng-show="documentMgr.busy">
+                <div class="spinner-new rotating"></div>
+            </div>
+            <div class="column-header">
+                <span class="col checkbox-col" ng-if="authentication.user">
+                    <input id="select-all" type="checkbox" title="Select All / None" ng-model="documentMgr.allChecked" ng-click="documentMgr.linkAll()"/>
+                    <label for="select-all">
+                        <span class="glyphicon glyphicon-ok"></span>
+                    </label>
+                </span>
+                <div class="fb-col-group">
+                    <div class="col name-col first-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('name')">
+                        <span>Name</span>
+                        <span class="sort-icon" ng-show="documentMgr.sorting.column === 'name'"></span>
                     </div>
-                </div><!-- / Column Header -->
-
-                <div class="scroll-container">
-                    <div class="scroll-container-inner">
-                        <div class="empty-directory-msg" ng-if="documentMgr.currentDirs.length == 0 && documentMgr.currentFiles.length == 0">This folder is empty.</div>
-                        <ul>
-                            <li class="fb-list-item" ng-class="{'selected': doc.selected}" ng-repeat="doc in documentMgr.currentDirs">
-                                <span class="col checkbox-col" ng-if="authentication.user">
-
-                                </span>
-                                <span class="fb-col-group"
-                                        ng-click="$event.originalEvent.dropdown || documentMgr.selectDir(doc)"
-                                        ng-dblclick="$event.originalEvent.dropdown || documentMgr.openDir(doc)" title="{{doc.model.name}}">
-                                    <span class="col name-col first-col">
-                                        <span class="avatar">
-                                            <span class="fb-folder glyphicon glyphicon-folder-close"></span>
-                                        </span>
-                                        <span class="name">
-                                            {{ doc.model.name }}
-                                        </span>
-                                    </span>
-                                    <span class="col date-col">---</span>
-                                    <span class="col size-col">---</span>
-                                    <span class="col status-col last-col" ng-if="authentication.user && publishedOnly !== 'true'">---</span>
-                                    <div class="row-actions"></div>
-                                </span>
-                            </li>
-                        </ul>
-                        <ul>
-                            <li class="fb-list-item" ng-class="{'selected': doc.selected}" ng-repeat="doc in documentMgr.currentFiles">
-                                <span class="col checkbox-col" ng-if="authentication.user">
-                                    <input id="{{doc._id}}" type="checkbox" ng-model="doc.selected" ng-click="documentMgr.linkFile(doc)"/>
-                                    <label for="{{doc._id}}" title="Select row">
-                                        <span class="glyphicon glyphicon-ok"></span>
-                                    </label>
-                                </span>
-                                <span class="fb-col-group"
-                                        ng-click="$event.originalEvent.dropdown || documentMgr.selectFile(doc)">
-                                    <span class="col name-col first-col" title="{{ doc.displayName | removeExtension }}">
-                                        <span class="avatar">
-                                            <span class="fb-file glyphicon glyphicon-file" ng-if="!['png','jpg','jpeg'].includes(doc.internalExt)"></span>
-                                            <span class="fb-img glyphicon glyphicon-picture" ng-if="['png','jpg','jpeg'].includes(doc.internalExt)"></span>
-                                        </span>
-                                        <span class="name">
-                                            {{ doc.displayName | removeExtension }}
-                                        </span>
-                                    </span>
-                                    <span class="col date-col">{{ doc.dateUploaded | date }}</span>
-                                    <span class="col size-col">{{ doc.internalSize | bytes:2 }}</span>
-                                    <span class="col status-col last-col" ng-if="authentication.user && publishedOnly !== 'true'">
-                                        <span class="label label-success" ng-if="doc.isPublished == true">PUBLISHED</span>
-                                        <span class="label label-unpublished" ng-if="doc.isPublished == false">UNPUBLISHED</span>
-                                    </span>
-                                </span>
-                            </li>
-                        </ul>
+                    <div class="col date-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('date')">
+                        <span>Uploaded</span>
+                        <span class="sort-icon" ng-show="documentMgr.sorting.column === 'date'"></span>
+                    </div>
+                    <div class="col size-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('size')">
+                        <span>Size</span>
+                        <span class="sort-icon" ng-show="documentMgr.sorting.column === 'size'"></span>
+                    </div>
+                    <div class="col status-col last-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('pub')" ng-if="authentication.user && publishedOnly !== 'true'">
+                        <span>Status</span>
+                        <span class="sort-icon" ng-show="documentMgr.sorting.column === 'pub'"></span>
                     </div>
                 </div>
-
+            </div>
+            <div class="scroll-container">
+                <div class="scroll-container-inner">
+                    <div class="empty-directory-msg" ng-if="documentMgr.currentDirs.length == 0 && documentMgr.currentFiles.length == 0">This folder is empty.</div>
+                    <ul class="folder-list">
+                        <li class="fb-list-item" ng-class="{'selected': doc.selected}" ng-repeat="doc in documentMgr.currentDirs">
+                            <span class="col checkbox-col" ng-if="authentication.user"></span>
+                            <span class="fb-col-group"
+                                ng-click="$event.originalEvent.dropdown || documentMgr.selectDir(doc)"
+                                ng-dblclick="$event.originalEvent.dropdown || documentMgr.openDir(doc)" title="{{doc.model.name}}">
+                                <span class="col name-col first-col">
+                                    <span class="avatar">
+                                        <span class="fb-folder glyphicon glyphicon-folder-close"></span>
+                                    </span>
+                                    <span class="name">
+                                        {{ doc.model.name }}
+                                    </span>
+                                </span>
+                                <span class="col date-col">---</span>
+                                <span class="col size-col">---</span>
+                                <span class="col status-col last-col" ng-if="authentication.user && publishedOnly !== 'true'">---</span>
+                                <div class="row-actions"></div>
+                            </span>
+                        </li>
+                    </ul>
+                    <ul class="file-list">
+                        <li class="fb-list-item" ng-class="{'selected': doc.selected}" ng-repeat="doc in documentMgr.currentFiles">
+                            <span class="col checkbox-col" ng-if="authentication.user">
+                                <input id="{{doc._id}}" type="checkbox" ng-model="doc.selected" ng-click="documentMgr.linkFile(doc)"/>
+                                <label for="{{doc._id}}" title="Select row">
+                                    <span class="glyphicon glyphicon-ok"></span>
+                                </label>
+                            </span>
+                            <span class="fb-col-group"
+                                    ng-click="$event.originalEvent.dropdown || documentMgr.selectFile(doc)">
+                                <span class="col name-col first-col" title="{{ doc.displayName | removeExtension }}">
+                                    <span class="avatar">
+                                        <span class="fb-file glyphicon glyphicon-file" ng-if="!['png','jpg','jpeg'].includes(doc.internalExt)"></span>
+                                        <span class="fb-img glyphicon glyphicon-picture" ng-if="['png','jpg','jpeg'].includes(doc.internalExt)"></span>
+                                    </span>
+                                    <span class="name">
+                                        {{ doc.displayName | removeExtension }}
+                                    </span>
+                                </span>
+                                <span class="col date-col">{{ doc.dateUploaded | date }}</span>
+                                <span class="col size-col">{{ doc.internalSize | bytes:2 }}</span>
+                                <span class="col status-col last-col" ng-if="authentication.user && publishedOnly !== 'true'">
+                                    <span class="label label-success" ng-if="doc.isPublished == true">PUBLISHED</span>
+                                    <span class="label label-unpublished" ng-if="doc.isPublished == false">UNPUBLISHED</span>
+                                </span>
+                            </span>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </div>
-
     </div>
 </section>
 
-<!-- Linked Files Section -->
-<section>
-    <label>Linked Files ({{linkedFiles.length}})</label>
+<section class="file-browser linked-files">
+    <h4>Linked Files ({{linkedFiles.length}})</h4>
     <div class="fb-body">
         <div class="fb-list">
-            <ul>
+            <ul class="file-list">
                 <li class="fb-list-item" ng-if="linkedFiles.length == 0">
                     <span class="col first-col">
                         No Documents linked.
@@ -138,7 +120,7 @@
                                 <span class="fb-file glyphicon glyphicon-file" ng-if="!['png','jpg','jpeg'].includes(doc.internalExt)"></span>
                                 <span class="fb-img glyphicon glyphicon-picture" ng-if="['png','jpg','jpeg'].includes(doc.internalExt)"></span>
                             </span>
-                            {{doc.displayName}}
+                            <span class="name">{{doc.displayName}}</span>
                         </span>
                         <div class="row-actions visible">
                             <button class="btn icon-btn"
@@ -151,4 +133,5 @@
             </ul>
         </div>
     </div>
-</section><!-- / Linked Files Section -->
+</section>
+

--- a/modules/documents/client/views/document-manager-move.html
+++ b/modules/documents/client/views/document-manager-move.html
@@ -1,5 +1,5 @@
 <!-- SELECTION DIALOG (step 1) -->
-<div ng-if="moveDlg.view === 'select'">
+<div class="document-manager-move" ng-if="moveDlg.view === 'select'">
   <div class="modal-header">
     <button type="button" class="btn btn-default close" ng-click="moveDlg.cancel()">
       <span aria-hidden="true">&times;</span>
@@ -9,7 +9,7 @@
 
   <div class="modal-body">
 
-    <div class="m-b-2">{{moveDlg.selectPromptText}}</div>
+    <div class="m-b-1">{{moveDlg.selectPromptText}}</div>
 
     <div class="file-browser">
       <div class="fb-header">
@@ -140,7 +140,7 @@
 <!-- / SELECTION DIALOG (step 1) -->
 
 <!-- CONFIRMATION DIALOG (step 2) -->
-<div class="confirm-dialog" ng-if="moveDlg.view === 'move'">
+<div class="document-manager-move confirm-dialog" ng-if="moveDlg.view === 'move'">
   <div class="modal-header">
     <button type="button" class="btn btn-default close" ng-click="moveDlg.cancel()">
       <span aria-hidden="true">&times;</span>

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -1,172 +1,193 @@
-	<div class="file-browser">
+<div class="file-browser">
 
 	<div class="fb-header">
 		<div class="fb-header-path">
-			<div class="fb-path"
-				ng-class="{'root':node.model.name == 'ROOT'}"
+			<div class="fb-path" ng-class="{'root':node.model.name == 'ROOT'}" 
 				ng-repeat="node in documentMgr.currentPath">
 				<span class="fb-path-arrow" ng-if="node.model.name != 'ROOT'">&rsaquo;</span>
-				<button class="btn icon-btn" title="{{ node.model.folderObj.displayName }}" ng-click="documentMgr.selectNode(node.model.id)">
+				<button class="btn icon-btn" title="{{ node.model.folderObj.displayName }}" 
+					ng-click="documentMgr.selectNode(node.model.id)">
 					<i class="glyphicon glyphicon glyphicon-home" ng-if="node.model.name == 'ROOT'"></i>
-					<span class="btn-txt" ng-if="node.model.name != 'ROOT'">{{ node.model.folderObj.displayName }}</span>
+					<span class="btn-txt" 
+						ng-if="node.model.name != 'ROOT'">
+						{{ node.model.folderObj.displayName }}
+					</span>
 				</button>
 			</div>
 		</div>
 		<div class="fb-header-actions">
-			<button class="btn icon-btn" title="Set Default Sort Order"
+			<button class="btn icon-btn" title="Set Default Sort Order" 
 				ng-if="project.userCan.manageFolders && documentMgr.currentNode.model.name !== 'ROOT'"
-				x-reorder-documents-modal
-				x-options="documentMgr.customSorter"
-				x-on-save="documentMgr.defaultSortOrderChanged"
+				x-reorder-documents-modal 
+				x-options="documentMgr.customSorter" 
+				x-on-save="documentMgr.defaultSortOrderChanged" 
 				x-folder="documentMgr.currentNode.model.folderObj"
 				x-current-path="documentMgr.currentPath">
 				<span class="glyphicon glyphicon-sort"></span>
 			</button>
-
-			<button class="btn icon-btn" title="Add New Folder"
-				ng-if="project.userCan.manageFolders"
+			<button class="btn icon-btn" title="Add New Folder" 
+				ng-if="project.userCan.manageFolders" 
 				ng-disabled="!documentMgr.selectedNode"
-				x-document-mgr-add-folder
-				x-project="project"
-				x-root="documentMgr.rootNode"
-				x-node="documentMgr.selectedNode"><span class="glyphicon glyphicon-folder-close"></span>
+				x-document-mgr-add-folder 
+				x-project="project" 
+				x-root="documentMgr.rootNode" 
+				x-node="documentMgr.selectedNode">
+				<span class="glyphicon glyphicon-folder-close"></span>
 			</button>
-
-			<button class="btn icon-btn" title="Upload Files"
-				ng-if="project.userCan.createDocument"
+			<button class="btn icon-btn" title="Upload Files" 
+				ng-if="project.userCan.createDocument" 
 				ng-disabled="!documentMgr.selectedNode"
-				x-document-mgr-upload-modal
-				x-project="project"
-				x-root="documentMgr.rootNode"
-				x-node="documentMgr.selectedNode"
-				x-type="'project'"><span class="glyphicon glyphicon-open"></span>
+				x-document-mgr-upload-modal x-project="project" 
+				x-root="documentMgr.rootNode" 
+				x-node="documentMgr.selectedNode" 
+				x-type="'project'">
+				<span class="glyphicon glyphicon-open"></span>
 			</button>
-
-			<button class="toggle-details-btn btn icon-btn" title="Properties"
-				ng-disabled="!documentMgr.lastChecked"
-				ng-click="documentMgr.infoPanel.toggle()"><span class="glyphicon glyphicon-info-sign"></span>
+			<button class="toggle-details-btn btn icon-btn" title="Properties" 
+				ng-disabled="!documentMgr.lastChecked" 
+				ng-click="documentMgr.infoPanel.toggle()">
+				<span class="glyphicon glyphicon-info-sign"></span>
 			</button>
-
-			<a class="btn icon-btn" href="{{documentMgr.folderURL}}" title="Sharable Link to this folder"><span class="glyphicon glyphicon-link"></span></a>
-
+			<a class="btn icon-btn" href="{{documentMgr.folderURL}}" title="Sharable Link to this folder">
+				<span class="glyphicon glyphicon-link"></span>
+			</a>
 			<div class="fb-menu btn-group">
-				<button type="button" class="btn icon-btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-disabled="!documentMgr.batchMenuEnabled">
+				<button class="btn icon-btn dropdown-toggle" type="button" 
+					data-toggle="dropdown" 
+					aria-haspopup="true" 
+					aria-expanded="false"
+				 	ng-disabled="!documentMgr.batchMenuEnabled">
 					<span class="glyphicon glyphicon glyphicon-option-vertical"></span>
 				</button>
 				<ul class="dropdown-menu pull-right">
 					<li>
-						<a title="Rename Folder"
-							ng-if="project.userCan.manageFolders"
-						    ng-show="documentMgr.checkedDirs.length === 1 && documentMgr.checkedFiles.length === 0"
-							x-document-mgr-rename-folder
-							x-project="project"
-							x-root="documentMgr.rootNode"
-							x-node="documentMgr.checkedDirs[0]"><span class="glyphicon glyphicon-edit"></span> Rename</a>
+						<a title="Rename Folder" 
+							ng-if="project.userCan.manageFolders" 
+							ng-show="documentMgr.checkedDirs.length === 1 && documentMgr.checkedFiles.length === 0"
+						 	x-document-mgr-rename-folder 
+						 	x-project="project" 
+						 	x-root="documentMgr.rootNode" 
+						 	x-node="documentMgr.checkedDirs[0]">
+							<span class="glyphicon glyphicon-edit"></span> Rename
+						</a>
 					</li>
 					<li>
-						<a title="Delete"
-              ng-hide="documentMgr.deleteSelected.confirmItems.length === 0"
-              x-confirm-delete
-              x-delete-callback="documentMgr.deleteFilesAndDirs"
-              x-current-node="documentMgr.currentNode"
-              x-project="project"
-              x-folders="documentMgr.checkedDirs"
-              x-files="documentMgr.checkedFiles">
-              <span class="glyphicon glyphicon-trash"></span> Delete</a>
+						<a title="Delete" 
+							ng-hide="documentMgr.deleteSelected.confirmItems.length === 0" 
+							x-confirm-delete x-delete-callback="documentMgr.deleteFilesAndDirs"
+							x-current-node="documentMgr.currentNode" 
+						 	x-project="project" 
+						 	x-folders="documentMgr.checkedDirs" 
+						 	x-files="documentMgr.checkedFiles">
+							<span class="glyphicon glyphicon-trash"></span> Delete
+						</a>
 					</li>
 					<li>
-						<a title="Publish"
-							 ng-hide="documentMgr.publishSelected.publishableFiles.length === 0"
-							 x-confirm-publish
-							 x-publisher="documentMgr.publishFiles"
-							 x-current-node="documentMgr.currentNode"
-							 x-docs="documentMgr.checkedFiles">
+						<a title="Publish" 
+							ng-hide="documentMgr.publishSelected.publishableFiles.length === 0" 
+							x-confirm-publish x-publisher="documentMgr.publishFiles"
+							x-current-node="documentMgr.currentNode" 
+							x-docs="documentMgr.checkedFiles">
 							<span class="glyphicon glyphicon-ok-circle"></span> Publish
 						</a>
 					</li>
 					<li>
-						<a title="Unpublish"
-						    ng-hide="documentMgr.publishSelected.unpublishableFiles.length === 0"
-						    x-confirm-dialog
-							x-title-text="'Unpublish File(s)'"
-							x-ok-text="documentMgr.publishSelected.okText"
-							x-cancel-text="documentMgr.publishSelected.cancelText"
+						<a title="Unpublish" 
+							ng-hide="documentMgr.publishSelected.unpublishableFiles.length === 0" 
+							x-confirm-dialog x-title-text="'Unpublish File(s)'"
+							x-ok-text="documentMgr.publishSelected.okText" 
+							x-cancel-text="documentMgr.publishSelected.cancelText" 
 							x-confirm-text="'Are you sure you want to unpublish the selected file(s)?'"
-							x-confirm-items="documentMgr.publishSelected.confirmItems"
-							x-on-ok="documentMgr.publishSelected.unpublish"><span class="glyphicon glyphicon-ban-circle"></span> Unpublish</a>
+							x-confirm-items="documentMgr.publishSelected.confirmItems" 
+							x-on-ok="documentMgr.publishSelected.unpublish">
+							<span class="glyphicon glyphicon-ban-circle"></span> Unpublish
+						</a>
 					</li>
 					<li>
-						<a title="Collections"
-							ng-show="project.userCan.manageFolders"
-							x-collection-chooser
-							x-project="project"
+						<a title="Collections" 
+							ng-show="project.userCan.manageFolders" 
+							x-collection-chooser x-project="project" 
 							x-docs="documentMgr.checkedFiles"
-							x-on-ok="documentMgr.updateCollections"
-							x-on-update="documentMgr.onDocumentUpdate"><span class="glyphicon glyphicon-list-alt"></span> Collections</a>
+							x-on-ok="documentMgr.updateCollections" 
+							x-on-update="documentMgr.onDocumentUpdate">
+							<span class="glyphicon glyphicon-list-alt"></span> Collections
+						</a>
 					</li>
 					<li>
-						<a title="Move Folders & Files"
-						   ng-hide="documentMgr.moveSelected.moveableFiles.length === 0 && documentMgr.moveSelected.moveableFolders.length === 0"
-						   x-document-mgr-move
-						   x-title-text="documentMgr.moveSelected.titleText"
-						   x-project="project"
-						   x-root="documentMgr.rootNode"
-						   x-node="documentMgr.rootNode"
-						   x-move-selected="documentMgr.moveSelected"><span class="glyphicon glyphicon-transfer"></span> Move to...</a>
+						<a title="Move Folders & Files" 
+							ng-hide="documentMgr.moveSelected.moveableFiles.length === 0 && documentMgr.moveSelected.moveableFolders.length === 0"
+							x-document-mgr-move x-title-text="documentMgr.moveSelected.titleText" 
+							x-project="project" 
+							x-root="documentMgr.rootNode"
+							x-node="documentMgr.rootNode" 
+							x-move-selected="documentMgr.moveSelected">
+							<span class="glyphicon glyphicon-transfer"></span> Move to...
+						</a>
 					</li>
 				</ul>
 			</div>
 		</div>
 	</div>
 	<div id="fbBody" class="fb-body" ng-class="{'panel-open': documentMgr.infoPanel.open}">
-
 		<div class="fb-list">
 
-			<!-- Load the File/Folder Directory -->
 			<div class="spinner-container" ng-show="documentMgr.busy">
 				<div class="spinner-new rotating"></div>
 			</div>
 
 			<div class="column-header">
 				<span class="col checkbox-col" ng-if="authentication.user">
-					<input id="select-all" type="checkbox" title="Select All / None" ng-model="documentMgr.allChecked" ng-click="documentMgr.checkAll()"/>
+					<input id="select-all" type="checkbox" title="Select All / None" 
+						ng-model="documentMgr.allChecked" 
+						ng-click="documentMgr.checkAll()"/>
 					<label for="select-all">
 						<span class="glyphicon glyphicon-ok"></span>
 					</label>
 				</span>
-
 				<div class="fb-col-group">
-					<div class="col name-col first-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('name')">
+					<div class="col name-col first-col sortable" 
+						ng-class="{'descending': !documentMgr.sorting.ascending}" 
+						ng-click="documentMgr.sortBy('name')">
 						<span>Name</span>
 						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'name'"></span>
 					</div>
-					<div class="col date-added-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('date')">
+					<div class="col date-added-col sortable" 
+						ng-class="{'descending': !documentMgr.sorting.ascending}" 
+						ng-click="documentMgr.sortBy('date')">
 						<span>Uploaded</span>
 						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'date'"></span>
 					</div>
-					<div class="col status-col last-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('pub')" ng-if="authentication.user">
+					<div class="col status-col last-col sortable" 
+						ng-class="{'descending': !documentMgr.sorting.ascending}" 
+						ng-click="documentMgr.sortBy('pub')"
+					 	ng-if="authentication.user">
 						<span>Status</span>
 						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'pub'"></span>
 					</div>
 				</div>
-
 			</div>
+
 			<div class="scroll-container">
 				<div class="scroll-container-inner">
-
-					<div class="empty-directory-msg" ng-if="documentMgr.currentDirs.length == 0 && documentMgr.currentFiles.length == 0">This folder is empty.</div>
+					<div class="empty-directory-msg" 
+						ng-if="documentMgr.currentDirs.length == 0 && documentMgr.currentFiles.length == 0">This folder is empty.
+					</div>
 
 					<ul>
-						<li class="fb-list-item" ng-class="{'selected': doc.selected}" ng-repeat="doc in documentMgr.currentDirs">
+						<li class="fb-list-item" 
+							ng-class="{'selected': doc.selected}" 
+							ng-repeat="doc in documentMgr.currentDirs">
 							<span class="col checkbox-col" ng-if="authentication.user">
-								<input id="{{doc.model.id}}" type="checkbox" ng-model="doc.selected" ng-click="documentMgr.checkDir(doc)"/>
+								<input type="checkbox" id="{{doc.model.id}}" 
+									ng-model="doc.selected" 
+									ng-click="documentMgr.checkDir(doc)" />
 								<label for="{{doc.model.id}}">
 									<span class="glyphicon glyphicon-ok"></span>
 								</label>
 							</span>
-							<span class="fb-col-group"
-								ng-click="$event.originalEvent.dropdown || documentMgr.selectDir(doc)"
-								ng-dblclick="$event.originalEvent.dropdown || documentMgr.openDir(doc)" title="{{doc.model.folderObj.displayName}}">
+							<span class="fb-col-group" title="{{doc.model.folderObj.displayName}}"
+								ng-click="$event.originalEvent.dropdown || documentMgr.selectDir(doc)" 
+								ng-dblclick="$event.originalEvent.dropdown || documentMgr.openDir(doc)">
 								<span class="col name-col first-col">
 									<span class="avatar">
 										<span class="fb-folder glyphicon glyphicon-folder-close"></span>
@@ -175,201 +196,235 @@
 										{{ doc.model.folderObj.displayName }}
 									</span>
 								</span>
-								<span hidden class="col author-col">---</span>
+								<span class="col author-col" hidden>---</span>
 								<span class="col date-added-col">---</span>
-								<span class="col status-col last-col" ng-if="authentication.user">
-									<span class="label label-success" ng-if="doc.model.published" title="Published">Published</span>
-									<span class="label label-unpublished" ng-if="!doc.model.published" title="Unpublished">Unpublished</span>
+								<span class="col status-col last-col" 
+									ng-if="authentication.user">
+									<span class="label label-success" title="Published" 
+										ng-if="doc.model.published">Published
+									</span>
+									<span class="label label-unpublished" title="Unpublished" 
+										ng-if="!doc.model.published">Unpublished
+									</span>
 								</span>
 								<div class="row-actions">
-
 									<div class="btn-group">
-										<button class="btn icon-btn dropdown-toggle" type="button" ng-click="$event.originalEvent.dropdown = true" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+										<button class="btn icon-btn dropdown-toggle" type="button" 
+											ng-click="$event.originalEvent.dropdown = true" 
+											data-toggle="dropdown"
+											aria-haspopup="true" 
+											aria-expanded="false">
 											<span class="glyphicon glyphicon glyphicon-option-vertical"></span>
 										</button>
 										<ul class="dropdown-menu pull-right">
 											<li ng-if="project.userCan.manageFolders">
-												<button class="btn icon-btn" title="Edit" ng-click="$event.stopPropagation();"
-														x-document-mgr-edit
-														x-project="project"
-														x-doc="doc"
-														x-on-update="documentMgr.onDocumentUpdate">
+												<button class="btn icon-btn" title="Edit" 
+													ng-click="$event.stopPropagation();" 
+													x-document-mgr-edit 
+													x-project="project" 
+													x-doc="doc"
+												 	x-on-update="documentMgr.onDocumentUpdate">
 													<span class="glyphicon glyphicon-edit"></span>
 												</button>
 											</li>
 											<li ng-if="project.userCan.manageFolders && !doc.model.published">
-												<button class="btn icon-btn" title="Publish Folder" ng-click="$event.stopPropagation();"
-														x-confirm-dialog
-														x-title-text="'Publish Folder'"
-														x-ok-text="'Yes'"
-														x-cancel-text="'No'"
-														x-confirm-text="'Are you sure you want to publish the selected folder?'"
-														x-confirm-items="[doc.model.folderObj.displayName]"
-														x-on-ok="documentMgr.publishFolder"
-														x-ok-args="doc">
+												<button class="btn icon-btn" title="Publish Folder" 
+													ng-click="$event.stopPropagation();" 
+													x-confirm-dialog 
+													x-title-text="'Publish Folder'"
+													x-ok-text="'Yes'" 
+													x-cancel-text="'No'" 
+													x-confirm-text="'Are you sure you want to publish the selected folder?'"
+													x-confirm-items="[doc.model.folderObj.displayName]" 
+													x-on-ok="documentMgr.publishFolder" 
+													x-ok-args="doc">
 													<span class="glyphicon glyphicon-ok-circle"></span>
 												</button>
 											</li>
 											<li ng-if="project.userCan.manageFolders && doc.model.published">
-												<button class="btn icon-btn" title="Unpublish Folder" ng-click="$event.stopPropagation();"
-														x-confirm-dialog
-														x-title-text="'Unpublish Folder'"
-														x-ok-text="'Yes'"
-														x-cancel-text="'No'"
-														x-confirm-text="'Are you sure you want to unpublish the selected folder?'"
-														x-confirm-items="[doc.model.folderObj.displayName]"
-														x-on-ok="documentMgr.unpublishFolder"
-														x-ok-args="doc">
+												<button class="btn icon-btn" title="Unpublish Folder" 
+													ng-click="$event.stopPropagation();" 
+													x-confirm-dialog x-title-text="'Unpublish Folder'"
+													x-ok-text="'Yes'" 
+												 	x-cancel-text="'No'" 
+												 	x-confirm-text="'Are you sure you want to unpublish the selected folder?'"
+												 	x-confirm-items="[doc.model.folderObj.displayName]" 
+												 	x-on-ok="documentMgr.unpublishFolder" 
+												 	x-ok-args="doc">
 													<span class="glyphicon glyphicon-ban-circle"></span>
 												</button>
 											</li>
 											<li ng-if="project.userCan.manageFolders">
-												<button class="btn icon-btn" title="Delete Folder" ng-click="$event.stopPropagation();"
-                          x-confirm-delete
-                          x-delete-callback="documentMgr.deleteFilesAndDirs"
-                          x-current-node="documentMgr.currentNode"
-                          x-project="project"
-                          x-folders="doc">
+												<button class="btn icon-btn" title="Delete Folder" 
+													ng-click="$event.stopPropagation();" 
+													x-confirm-delete x-delete-callback="documentMgr.deleteFilesAndDirs"
+												 	x-current-node="documentMgr.currentNode" 
+												 	x-project="project" 
+												 	x-folders="doc">
 													<span class="glyphicon glyphicon-trash"></span>
 												</button>
 											</li>
 											<li ng-if="project.userCan.manageFolders">
-												<button class="btn icon-btn" title="Edit Permissions" ng-click="$event.stopPropagation();"
-														x-role-permissions-modal
-														x-context="project"
-														x-object="doc.model.folderObj"
-														x-reload="'false'"
-														x-callback="documentMgr.onPermissionsUpdate">
-													<span class="glyphicon glyphicon-cog"></span></button>
+												<button class="btn icon-btn" title="Edit Permissions" 
+													ng-click="$event.stopPropagation();" 
+													x-role-permissions-modal 
+													x-context="project"
+												 	x-object="doc.model.folderObj" 
+												 	x-reload="'false'" 
+												 	x-callback="documentMgr.onPermissionsUpdate">
+													<span class="glyphicon glyphicon-cog"></span>
 												</button>
 											</li>
 											<li>
-												<button class="btn icon-btn" title="Properties" ng-click="documentMgr.infoPanel.toggle();$event.stopPropagation();">
+												<button class="btn icon-btn" title="Properties" 
+													ng-click="documentMgr.infoPanel.toggle();$event.stopPropagation();">
 													<span class="glyphicon glyphicon-info-sign"></span>
 												</button>
 											</li>
 										</ul>
 									</div>
-									<button class="drill-in-btn btn icon-btn" ng-click="documentMgr.openDir(doc)">
+									<button class="drill-in-btn btn icon-btn" 
+										ng-click="documentMgr.openDir(doc)">
 										<span class="glyphicon glyphicon-menu-right"></span>
 									</button>
 								</div>
 							</span>
 						</li>
 					</ul>
+
 					<ul>
-						<li class="fb-list-item" ng-class="{'selected': doc.selected}" ng-repeat="doc in documentMgr.currentFiles">
-							<span class="col checkbox-col" ng-if="authentication.user">
-								<input id="{{doc._id}}" type="checkbox" ng-model="doc.selected" ng-click="documentMgr.checkFile(doc)"/>
-								<label for="{{doc._id}}" title="Select row">
+						<li class="fb-list-item" 
+							ng-class="{'selected': doc.selected}" 
+							ng-repeat="doc in documentMgr.currentFiles">
+							<span class="col checkbox-col" 
+								ng-if="authentication.user">
+								<input type="checkbox"  id="{{doc._id}}"
+									ng-model="doc.selected" 
+									ng-click="documentMgr.checkFile(doc)" />
+								<label title="Select row" for="{{doc._id}}">
 									<span class="glyphicon glyphicon-ok"></span>
 								</label>
 							</span>
-							<span class="fb-col-group" ng-dblclick="documentMgr.dblClick(doc)"
+							<span class="fb-col-group" 
+								ng-dblclick="documentMgr.dblClick(doc)" 
 								ng-click="$event.originalEvent.dropdown || documentMgr.selectFile(doc)">
 								<span class="col name-col first-col" title="{{ doc.displayName | removeExtension }}">
 									<span class="avatar">
-										<span class="fb-file glyphicon glyphicon-file" ng-if="!['png','jpg','jpeg'].includes(doc.internalExt)"></span>
-										<span class="fb-img glyphicon glyphicon-picture" ng-if="['png','jpg','jpeg'].includes(doc.internalExt)"></span>
+										<span class="fb-file glyphicon glyphicon-file" 
+											ng-if="!['png','jpg','jpeg'].includes(doc.internalExt)">
+										</span>
+										<span class="fb-img glyphicon glyphicon-picture" 
+											ng-if="['png','jpg','jpeg'].includes(doc.internalExt)">
+										</span>
 									</span>
 									<span class="name">
 										{{ doc.displayName | removeExtension }}
 									</span>
 								</span>
-								<span hidden class="col author-col" title="{{ doc.documentAuthor }}">
+								<span class="col author-col" title="{{ doc.documentAuthor }}" hidden>
 									{{ doc.documentAuthor }}
 								</span>
 								<span class="col date-added-col">{{ doc.dateUploaded | date : format : timezone }}</span>
-								<span class="col status-col last-col" ng-if="authentication.user">
-									<span class="label label-success" ng-if="doc.isPublished && documentMgr.currentPathIsPublished" title="Published">Published</span>
-									<span class="label label-unpublished" ng-if="doc.isPublished && !documentMgr.currentPathIsPublished" title="Published">Published</span>
-									<span class="label label-unpublished" ng-if="!doc.isPublished" title="Unpublished">Unpublished</span>
+								<span class="col status-col last-col" 
+									ng-if="authentication.user">
+									<span class="label label-success" title="Published"
+										ng-if="doc.isPublished && documentMgr.currentPathIsPublished">Published
+									</span>
+									<span class="label label-unpublished" title="Published"
+										ng-if="doc.isPublished && !documentMgr.currentPathIsPublished">Published</span>
+									<span class="label label-unpublished" title="Unpublished"
+										ng-if="!doc.isPublished">Unpublished</span>
 								</span>
 								<div class="row-actions">
-
 									<div class="btn-group">
-										<button class="btn icon-btn dropdown-toggle" type="button" ng-click="$event.originalEvent.dropdown = true" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-											<span class="glyphicon glyphicon glyphicon-option-vertical" ></span>
+										<button class="btn icon-btn dropdown-toggle" type="button" 
+											ng-click="$event.originalEvent.dropdown = true" 
+											data-toggle="dropdown"
+											aria-haspopup="true" 
+											aria-expanded="false">
+											<span class="glyphicon glyphicon glyphicon-option-vertical"></span>
 										</button>
 										<ul class="dropdown-menu pull-right">
 											<li ng-if="doc.userCan.read">
 												<a class="btn icon-btn" href="/api/document/{{ doc._id }}/fetch" target="_blank" title="Download File">
-													<span class="glyphicon glyphicon-download-alt"></span></a>
+													<span class="glyphicon glyphicon-download-alt"></span>
+												</a>
 											</li>
 											<li ng-if="doc.userCan.write">
-												<button class="btn icon-btn" title="Edit File"
-														ng-if="doc.userCan.write"
-														x-document-mgr-edit
-														x-project="project"
-														x-doc="doc"
-														x-on-update="documentMgr.onDocumentUpdate">
+												<button class="btn icon-btn" title="Edit File" 
+													ng-if="doc.userCan.write" 
+													x-document-mgr-edit x-project="project" 
+													x-doc="doc"
+												 	x-on-update="documentMgr.onDocumentUpdate">
 													<span class="glyphicon glyphicon-edit"></span>
 												</button>
 											</li>
 											<li>
-												<button class="btn icon-btn" title="Copy Link to Clipboard"
-													ngclipboard
-													data-clipboard-text="{{ doc.link }}"
+												<button class="btn icon-btn" title="Copy Link to Clipboard" 
+													ngclipboard 
+													data-clipboard-text="{{ doc.link }}" 
 													data-doc-name="{{ doc.displayName }}"
-													ngclipboard-success="copyClipboardSuccess(e);"
+													ngclipboard-success="copyClipboardSuccess(e);" 
 													ngclipboard-error="copyClipboardError(e);">
 													<span class="glyphicon glyphicon-copy"></span>
 												</button>
 											</li>
 											<li ng-if="doc.userCan.publish && !doc.isPublished">
-												<button class="btn icon-btn" title="Publish File" ng-click="$event.stopPropagation();"
-													x-confirm-publish
+												<button class="btn icon-btn" title="Publish File" 
+													ng-click="$event.stopPropagation();" 
+													x-confirm-publish 
 													x-publisher="documentMgr.publishFiles"
-													x-current-node="documentMgr.currentNode"
+													x-current-node="documentMgr.currentNode" 
 													x-docs="doc">
 													<span class="glyphicon glyphicon-ok-circle"></span>
 												</button>
 											</li>
 											<li ng-if="doc.userCan.unPublish && doc.isPublished">
-												<button class="btn icon-btn" title="Unpublish File" ng-click="$event.stopPropagation();"
-														x-confirm-dialog
-														x-title-text="'Unpublish File(s)'"
-														x-ok-text="'Yes'"
-														x-cancel-text="'No'"
-														x-confirm-text="'Are you sure you want to unpublish the selected file?'"
-														x-confirm-items="[doc.displayName]"
-														x-on-ok="documentMgr.unpublishFile"
-														x-ok-args="doc">
+												<button class="btn icon-btn" title="Unpublish File" 
+													ng-click="$event.stopPropagation();" 
+													x-confirm-dialog x-title-text="'Unpublish File(s)'"
+													x-ok-text="'Yes'" 
+													x-cancel-text="'No'" 
+													x-confirm-text="'Are you sure you want to unpublish the selected file?'"
+													x-confirm-items="[doc.displayName]" 
+													x-on-ok="documentMgr.unpublishFile" 
+													x-ok-args="doc">
 													<span class="glyphicon glyphicon-ban-circle"></span>
 												</button>
 											</li>
 											<li ng-if="doc.userCan.delete">
-												<button class="btn icon-btn" title="Delete File" ng-click="$event.stopPropagation();"
-                          x-confirm-delete
-                          x-current-node="documentMgr.currentNode"
-                          x-project="project"
-                          x-delete-callback="documentMgr.deleteFilesAndDirs"
-                          x-files="doc">
+												<button class="btn icon-btn" title="Delete File" 
+													ng-click="$event.stopPropagation();" 
+													x-confirm-delete x-current-node="documentMgr.currentNode"
+													x-project="project" 
+													x-delete-callback="documentMgr.deleteFilesAndDirs" 
+													x-files="doc">
 													<span class="glyphicon glyphicon-trash"></span>
 												</button>
 											</li>
 											<li ng-if="project.userCan.manageDocumentPermissions">
-												<button class="btn icon-btn" title="Edit Permissions" ng-click="$event.stopPropagation();"
-														x-role-permissions-modal
-														x-context="project"
-														x-object="doc"
-														x-reload="'false'"
-														x-callback="documentMgr.onPermissionsUpdate">
-													<span class="glyphicon glyphicon-cog"></span></button>
+												<button class="btn icon-btn" title="Edit Permissions" 
+													ng-click="$event.stopPropagation();" 
+													x-role-permissions-modal x-context="project"
+													x-object="doc" 
+													x-reload="'false'" 
+													x-callback="documentMgr.onPermissionsUpdate">
+													<span class="glyphicon glyphicon-cog"></span>
 												</button>
 											</li>
 											<li>
-												<button class="btn icon-btn" title="Properties" ng-click="documentMgr.infoPanel.toggle();$event.stopPropagation();">
+												<button class="btn icon-btn" title="Properties" 
+													ng-click="documentMgr.infoPanel.toggle();$event.stopPropagation();">
 													<span class="glyphicon glyphicon-info-sign"></span>
 												</button>
 											</li>
 										</ul>
 									</div>
-
 								</div>
 							</span>
 						</li>
 					</ul>
+
 				</div>
 			</div>
 
@@ -377,88 +432,97 @@
 
 		<div class="fb-details-panel">
 			<!-- Load the File/Folder Details -->
-			<div class="spinner-container" ng-show="documentMgr.busy">
+			<div class="spinner-container" 
+				ng-show="documentMgr.busy">
 				<div class="spinner-new rotating"></div>
 			</div>
 
 			<!-- FILE DETAILS -->
-			<div class="fb-details-content" ng-if="documentMgr.infoPanel.data && documentMgr.infoPanel.type === 'File'">
+			<div class="fb-details-content" 
+				ng-if="documentMgr.infoPanel.data && documentMgr.infoPanel.type === 'File'">
 				<div class="title-panel">
 					<div class="title-panel-info">
-						<button class="btn btn-default close" type="button" ng-click="documentMgr.infoPanel.close()">
+						<button class="btn btn-default close" type="button" 
+							ng-click="documentMgr.infoPanel.close()">
 							<span aria-hidden="true">&times;</span>
 						</button>
 						<h2 title="{{documentMgr.infoPanel.data.displayName | removeExtension}}">{{documentMgr.infoPanel.data.displayName | removeExtension }}</h2>
 					</div>
 					<div class="title-panel-btns">
-						<button class="btn btn-sm btn-default" title="Copy Link to Clipboard"
-										ngclipboard
-										data-doc-name="documentMgr.infoPanel.data.displayName"
-										data-clipboard-text="{{ documentMgr.infoPanel.data.link }}"
-										ngclipboard-success="copyClipboardSuccess(e);"
-										ngclipboard-error="copyClipboardError(e);">
+						<button class="btn btn-sm btn-default" title="Copy Link to Clipboard" 
+							ngclipboard 
+							data-doc-name="documentMgr.infoPanel.data.displayName"
+							data-clipboard-text="{{ documentMgr.infoPanel.data.link }}" 
+							ngclipboard-success="copyClipboardSuccess(e);" 
+							ngclipboard-error="copyClipboardError(e);">
 							<span class="glyphicon glyphicon-copy"></span>
 						</button>
-						<a ng-if="documentMgr.infoPanel.data.userCan.read"
-						   class="btn btn-sm btn-default"
-						   href="/api/document/{{ documentMgr.infoPanel.data._id }}/fetch"
-						   target="_blank"
-						   title="Download File"><span class="glyphicon glyphicon-download-alt"></span></a>
-						<button class="btn btn-sm btn-default" ng-if="documentMgr.infoPanel.data.userCan.write"
-								x-document-mgr-edit
-								x-project="project"
-								x-doc="documentMgr.infoPanel.data"
-								x-on-update="documentMgr.onDocumentUpdate">Edit</button>
+						<a class="btn btn-sm btn-default" title="Download File" href="/api/document/{{ documentMgr.infoPanel.data._id }}/fetch"target="_blank"
+							ng-if="documentMgr.infoPanel.data.userCan.read">
+							<span class="glyphicon glyphicon-download-alt"></span>
+						</a>
+						<button class="btn btn-sm btn-default" 
+							ng-if="documentMgr.infoPanel.data.userCan.write" 
+							x-document-mgr-edit x-project="project"
+						 	x-doc="documentMgr.infoPanel.data" 
+							x-on-update="documentMgr.onDocumentUpdate">Edit
+						</button>
 						<div class="fb-menu btn-group">
 							<button class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown">More</button>
 							<ul class="dropdown-menu pull-right">
 								<li ng-if="documentMgr.infoPanel.data.userCan.delete">
-									<a title="Delete File"
-                    ng-click="$event.stopPropagation();"
-                    x-confirm-delete
-                    x-current-node="documentMgr.currentNode"
-                    x-project="project"
-                    x-delete-callback="documentMgr.deleteFilesAndDirs"
-                    x-files="documentMgr.infoPanel.data">
-                    <span class="glyphicon glyphicon-trash"></span> Delete</a>
+									<a title="Delete File" 
+										ng-click="$event.stopPropagation();" 
+										x-confirm-delete x-current-node="documentMgr.currentNode" 
+										x-project="project"
+									 	x-delete-callback="documentMgr.deleteFilesAndDirs" 
+									 	x-files="documentMgr.infoPanel.data">
+										<span class="glyphicon glyphicon-trash"></span> Delete
+									</a>
 								</li>
 								<li ng-if="documentMgr.infoPanel.data.userCan.publish && !documentMgr.infoPanel.data.isPublished">
-									<a title="Publish File"
-									   ng-click="$event.stopPropagation();"
-                     x-confirm-publish
-                     x-publisher="documentMgr.publishFiles"
-                     x-current-node="documentMgr.currentNode"
-                     x-docs="documentMgr.infoPanel.data">
-                    <span class="glyphicon glyphicon-ok-circle"></span> Publish</a>
+									<a title="Publish File" 
+										ng-click="$event.stopPropagation();" 
+										x-confirm-publish 
+										x-publisher="documentMgr.publishFiles" 
+										x-current-node="documentMgr.currentNode"
+										x-docs="documentMgr.infoPanel.data">
+										<span class="glyphicon glyphicon-ok-circle"></span> Publish
+									</a>
 								</li>
 								<li ng-if="documentMgr.infoPanel.data.userCan.unPublish && documentMgr.infoPanel.data.isPublished">
-									<a title="Unpublish File"
-									   ng-click="$event.stopPropagation();"
-									   x-confirm-dialog
-									   x-title-text="'Unpublish File'"
-									   x-ok-text="'Yes'"
-									   x-cancel-text="'No'"
-									   x-confirm-text="'Are you sure you want to unpublish the selected file?'"
-									   x-confirm-items="[documentMgr.infoPanel.data.displayName]"
-									   x-on-ok="documentMgr.unpublishFile"
-									   x-ok-args="documentMgr.infoPanel.data"><span class="glyphicon glyphicon-ban-circle"></span> Unpublish</a>
+									<a title="Unpublish File" 
+										ng-click="$event.stopPropagation();" 
+										x-confirm-dialog x-title-text="'Unpublish File'" 
+										x-ok-text="'Yes'"
+										x-cancel-text="'No'" 
+										x-confirm-text="'Are you sure you want to unpublish the selected file?'" 
+										x-confirm-items="[documentMgr.infoPanel.data.displayName]"
+										x-on-ok="documentMgr.unpublishFile" 
+										x-ok-args="documentMgr.infoPanel.data">
+										<span class="glyphicon glyphicon-ban-circle"></span> Unpublish
+									</a>
 								</li>
 								<li ng-if="project.userCan.manageFolders">
-									<a title="Collections"
-										x-collection-chooser
-										x-project="project"
-										x-docs="documentMgr.infoPanel.data"
+									<a title="Collections" 
+										x-collection-chooser x-project="project" 
+										x-docs="documentMgr.infoPanel.data" 
 										x-current="documentMgr.infoPanel.data.collections"
-										x-on-ok="documentMgr.updateCollections"
-										x-on-update="documentMgr.onDocumentUpdate"><span class="glyphicon glyphicon-list-alt"></span> Update Collections</a>
+										x-on-ok="documentMgr.updateCollections" 
+										x-on-update="documentMgr.onDocumentUpdate">
+										<span class="glyphicon glyphicon-list-alt"></span> Update Collections
+									</a>
 								</li>
 								<li>
-									<a title="Edit Permissions" ng-if="project.userCan.manageDocumentPermissions"
-										x-role-permissions-modal
+									<a title="Edit Permissions" 
+										ng-if="project.userCan.manageDocumentPermissions" 
+										x-role-permissions-modal 
 										x-context="project"
-										x-object="documentMgr.infoPanel.data"
-									    x-reload="'false'"
-									    x-callback="documentMgr.onPermissionsUpdate"><span class="glyphicon glyphicon-cog"></span> Edit Permissions</a>
+										x-object="documentMgr.infoPanel.data" 
+										x-reload="'false'" 
+										x-callback="documentMgr.onPermissionsUpdate">
+										<span class="glyphicon glyphicon-cog"></span> Edit Permissions
+									</a>
 								</li>
 							</ul>
 						</div>
@@ -476,9 +540,15 @@
 								<li ng-if="authentication.user">
 									<span class="name">Status:</span>
 									<span class="value">
-										<span class="label label-success" ng-if="documentMgr.infoPanel.data.isPublished && documentMgr.currentPathIsPublished" title="Published">Published</span>
-										<span class="label label-unpublished" ng-if="documentMgr.infoPanel.data.isPublished && !documentMgr.currentPathIsPublished" title="Published">Published</span>
-										<span class="label label-unpublished" ng-if="!documentMgr.infoPanel.data.isPublished" title="Unpublished">Unpublished</span>
+										<span class="label label-success" title="Published"
+											ng-if="documentMgr.infoPanel.data.isPublished && documentMgr.currentPathIsPublished">Published
+										</span>
+										<span class="label label-unpublished" title="Published"
+											ng-if="documentMgr.infoPanel.data.isPublished && !documentMgr.currentPathIsPublished">Published
+										</span>
+										<span class="label label-unpublished" title="Unpublished"
+											ng-if="!documentMgr.infoPanel.data.isPublished">Unpublished
+										</span>
 									</span>
 								</li>
 								<li>
@@ -491,7 +561,9 @@
 								</li>
 								<li>
 									<span class="name">Link:</span>
-									<span class="value break-all"><a href="{{documentMgr.infoPanel.data.link}}" target="_blank">{{ documentMgr.infoPanel.data.link }}</a></span>
+									<span class="value break-all">
+										<a href="{{documentMgr.infoPanel.data.link}}" target="_blank">{{ documentMgr.infoPanel.data.link }}</a>
+									</span>
 								</li>
 								<li>
 									<span class="name">Size:</span>
@@ -520,7 +592,9 @@
 								<li ng-if="project.userCan.manageFolders && documentMgr.infoPanel.data.collections.length > 0">
 									<span class="name">Collection(s):</span>
 									<ul class="value">
-										<li data-ng-repeat="collection in documentMgr.infoPanel.data.collections"><a ui-sref="p.collection.detail({ collectionId: collection._id })">{{ collection.displayName }}</a></li>
+										<li data-ng-repeat="collection in documentMgr.infoPanel.data.collections">
+											<a ui-sref="p.collection.detail({ collectionId: collection._id })">{{ collection.displayName }}</a>
+										</li>
 									</ul>
 								</li>
 							</ul>
@@ -528,7 +602,8 @@
 
 					</section>
 				</div>
-			</div><!-- / FILE DETAILS -->
+			</div>
+			<!-- / FILE DETAILS -->
 
 			<!-- DIRECTORY DETAILS -->
 			<div class="fb-details-content" ng-if="documentMgr.infoPanel.data && documentMgr.infoPanel.type === 'Directory'">
@@ -551,9 +626,14 @@
 							<li ng-if="authentication.user">
 								<span class="name">Status:</span>
 								<span class="value">
-									<span class="label label-success" ng-if="documentMgr.infoPanel.data.folderObj.isPublished && documentMgr.currentPathIsPublished">Published</span>
-									<span class="label label-unpublished" ng-if="documentMgr.infoPanel.data.folderObj.isPublished && !documentMgr.currentPathIsPublished">Published</span>
-									<span class="label label-unpublished" ng-if="!documentMgr.infoPanel.data.folderObj.isPublished">Unpublished</span>
+									<span class="label label-success" title="Published"
+										ng-if="documentMgr.infoPanel.data.folderObj.isPublished && documentMgr.currentPathIsPublished">Published
+									</span>
+									<span class="label label-unpublished" title="Published"
+										ng-if="documentMgr.infoPanel.data.folderObj.isPublished && !documentMgr.currentPathIsPublished">Published
+									</span>
+									<span class="label label-unpublished" title="Unpublished"
+										ng-if="!documentMgr.infoPanel.data.folderObj.isPublished">Unpublished</span>
 								</span>
 							</li>
 							<li>
@@ -563,7 +643,8 @@
 						</ul>
 					</section>
 				</div>
-			</div><!-- / DIRECTORY DETAILS -->
+			</div>
+			<!-- / DIRECTORY DETAILS -->
 
 			<!-- NO DETAILS -->
 			<div class="fb-details-content" ng-if="documentMgr.infoPanel.data && documentMgr.infoPanel.type === 'Multi'">
@@ -576,13 +657,16 @@
 					</div>
 				</div>
 				<div class="scroll-container">
-					There are {{documentMgr.infoPanel.data.checkedFiles}} files and {{documentMgr.infoPanel.data.checkedDirs}} folders selected.<br>Select one file or folder to view details.
+					There are {{documentMgr.infoPanel.data.checkedFiles}} files and {{documentMgr.infoPanel.data.checkedDirs}} folders selected.
+					<br>Select one file or folder to view details.
 				</div>
 			</div>
-			<div class="fb-details-content" ng-if="!documentMgr.infoPanel.data || documentMgr.infoPanel.type === 'None'">
+			<div class="fb-details-content" 
+				ng-if="!documentMgr.infoPanel.data || documentMgr.infoPanel.type === 'None'">
 				<div class="title-panel">
 					<div class="title-panel-info">
-						<button class="btn btn-default close" type="button" ng-click="documentMgr.infoPanel.close()">
+						<button class="btn btn-default close" type="button" 
+							ng-click="documentMgr.infoPanel.close()">
 							<span aria-hidden="true">&times;</span>
 						</button>
 						<h2 title="{{project.name}}">{{project.name}}</h2>
@@ -591,7 +675,8 @@
 				<div class="scroll-container">
 					Select one file or folder to view details.
 				</div>
-			</div><!-- / NO DETAILS -->
+			</div>
+			<!-- / NO DETAILS -->
 
 		</div>
 

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -173,7 +173,7 @@
 						ng-if="documentMgr.currentDirs.length == 0 && documentMgr.currentFiles.length == 0">This folder is empty.
 					</div>
 
-					<ul>
+					<ul class="folder-list">
 						<li class="fb-list-item" 
 							ng-class="{'selected': doc.selected}" 
 							ng-repeat="doc in documentMgr.currentDirs">
@@ -292,7 +292,7 @@
 						</li>
 					</ul>
 
-					<ul>
+					<ul class="file-list">
 						<li class="fb-list-item" 
 							ng-class="{'selected': doc.selected}" 
 							ng-repeat="doc in documentMgr.currentFiles">

--- a/modules/users/client/directives/dropzone.move.directive.js
+++ b/modules/users/client/directives/dropzone.move.directive.js
@@ -24,7 +24,6 @@ angular.module('documents')
 						$modal.open({
 						animation: true,
 						size: 'lg',
-						windowClass: 'fb-browser-modal',
 						templateUrl: 'modules/users/client/views/user-partials/dropzone-move.html',
 						resolve: {},
 						controllerAs: 'moveDlg',


### PR DESCRIPTION
Fixed an issued with long files names in both the Document Manager and Document Link Interface.

Additional Fixes
- Added ability to select text in document manager interface
- Added separate files to accommodate separate pieces of document manager functionality
- Removed 'fb-browser-modal' class and moved discrete styling to specific functionality (see previous)