### PR TITLE
[EPIC-1276] Change 'Uploaded Date' to 'Document Date'

### DIFF
--- a/modules/core/client/scss/components/file-browser.scss
+++ b/modules/core/client/scss/components/file-browser.scss
@@ -552,15 +552,6 @@ a.icon-btn {
 }
 
 @media only screen
-    and (max-device-width: 768px) {
-    .fb-list {
-        .col + .col {
-            display: none;
-        }
-    }
-}
-
-@media only screen
     and (max-device-width: 1024px) {
     .fb-list {
         .fb-col-group {
@@ -601,14 +592,6 @@ span.avatar {
     &.size-col {
         @include flex(0 0 18%)
     }
-
-    &.status-col {
-        @include flex(0 0 18%)
-    }
-
-    &.status-col {
-        @include flex(0 0 26%)
-    }
 }
 
 .col.size-col{
@@ -625,10 +608,6 @@ span.avatar {
 
 .col.status-col {
     @include flex(0 0 26%);
-}
-
-.col.date-added-col {
-    @include flex(0 0 24%);
 }
 
 
@@ -771,7 +750,8 @@ span.avatar {
                     white-space: nowrap;
                     overflow: hidden;
                     text-overflow: ellipsis;
-                    font-size: 2.2rem;
+                    font-size: 2rem;
+                    font-weight: bold;
                 }
 
                 .close {
@@ -792,7 +772,7 @@ span.avatar {
         }
 
         .title-panel-btns {
-            padding-top: 1.5rem;
+            padding-top: 1.75rem;
         }
 
         section {
@@ -810,7 +790,7 @@ span.avatar {
             h3 {
                 margin-top: 0;
                 margin-bottom: 1rem;
-                font-size: 1.6rem;
+                font-size: 1.4rem;
                 font-weight: bold;
                 border-bottom: none;
             }

--- a/modules/core/client/scss/global/mixins.scss
+++ b/modules/core/client/scss/global/mixins.scss
@@ -30,6 +30,12 @@
 	flex-direction: $values;
 }
 
+@mixin flexbasis($values) {
+	-webkit-flex-basis: $values;
+	-ms-flex-basis: $values;
+	flex-basis: $values;
+}
+
 @mixin flexflow($values) {
 	-webkit-flex-flow: $values;
 	-ms-flex-flow: $values;

--- a/modules/documents/client/scss/document-manager-link.scss
+++ b/modules/documents/client/scss/document-manager-link.scss
@@ -12,6 +12,13 @@
     }
 
     .file-browser {
+        .col {
+            &.date-col,
+            &.status-col {
+                @include flexbasis(18rem); 
+            }
+        }
+
         .folder-list {
             .col {
                 &.name-col {

--- a/modules/documents/client/scss/document-manager.scss
+++ b/modules/documents/client/scss/document-manager.scss
@@ -10,23 +10,62 @@
         right: 1rem;
         bottom: 1rem;
         left: 1rem;
+    }
+}
 
-        .folder-list {
+@media (max-width: 768px) {
+    .document-manager {
+        .file-browser {
             .col {
-                &.name-col {
-                    .name {
-                        right: 10rem;
+                &.date-col,
+                &.status-col {
+                    display: none;
+                }
+            }
+
+            .folder-list {
+                .col {
+                    &.name-col {
+                        .name {
+                            right: 10rem;
+                        }
+                    }
+                }
+            }
+    
+            .file-list {
+                .col {
+                    &.name-col {
+                        .name {
+                            right: 5rem;
+                        }
                     }
                 }
             }
         }
+    }
+}
 
-        .file-list {
+@media (min-width: 1024px) {
+    .document-manager {
+        .file-browser {
             .col {
-                &.name-col {
-                    .name {
-                        right: 5rem;
-                    }
+                &.date-col,
+                &.status-col {
+                    @include flexbasis(25%); 
+                }
+            }
+        }
+    }
+}
+
+@media (min-width: 1600px) {
+    .document-manager {
+        .file-browser {
+            .col {
+                &.date-col,
+                &.status-col {
+                   @include flexbasis(20%); 
                 }
             }
         }

--- a/modules/documents/client/views/document-manager-link.html
+++ b/modules/documents/client/views/document-manager-link.html
@@ -32,12 +32,8 @@
                         <span class="sort-icon" ng-show="documentMgr.sorting.column === 'name'"></span>
                     </div>
                     <div class="col date-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('date')">
-                        <span>Uploaded</span>
+                        <span>Document Date</span>
                         <span class="sort-icon" ng-show="documentMgr.sorting.column === 'date'"></span>
-                    </div>
-                    <div class="col size-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('size')">
-                        <span>Size</span>
-                        <span class="sort-icon" ng-show="documentMgr.sorting.column === 'size'"></span>
                     </div>
                     <div class="col status-col last-col sortable" ng-class="{'descending': !documentMgr.sorting.ascending}" ng-click="documentMgr.sortBy('pub')" ng-if="authentication.user && publishedOnly !== 'true'">
                         <span>Status</span>
@@ -63,9 +59,7 @@
                                     </span>
                                 </span>
                                 <span class="col date-col">---</span>
-                                <span class="col size-col">---</span>
                                 <span class="col status-col last-col" ng-if="authentication.user && publishedOnly !== 'true'">---</span>
-                                <div class="row-actions"></div>
                             </span>
                         </li>
                     </ul>
@@ -88,8 +82,7 @@
                                         {{ doc.displayName | removeExtension }}
                                     </span>
                                 </span>
-                                <span class="col date-col">{{ doc.dateUploaded | date }}</span>
-                                <span class="col size-col">{{ doc.internalSize | bytes:2 }}</span>
+                                <span class="col date-col">{{ doc.documentDate | date }}</span>
                                 <span class="col status-col last-col" ng-if="authentication.user && publishedOnly !== 'true'">
                                     <span class="label label-success" ng-if="doc.isPublished == true">PUBLISHED</span>
                                     <span class="label label-unpublished" ng-if="doc.isPublished == false">UNPUBLISHED</span>

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -151,10 +151,10 @@
 						<span>Name</span>
 						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'name'"></span>
 					</div>
-					<div class="col date-added-col sortable" 
+					<div class="col date-col sortable" 
 						ng-class="{'descending': !documentMgr.sorting.ascending}" 
 						ng-click="documentMgr.sortBy('date')">
-						<span>Uploaded</span>
+						<span>Document Date</span>
 						<span class="sort-icon" ng-show="documentMgr.sorting.column === 'date'"></span>
 					</div>
 					<div class="col status-col last-col sortable" 
@@ -196,8 +196,7 @@
 										{{ doc.model.folderObj.displayName }}
 									</span>
 								</span>
-								<span class="col author-col" hidden>---</span>
-								<span class="col date-added-col">---</span>
+								<span class="col date-col">---</span>
 								<span class="col status-col last-col" 
 									ng-if="authentication.user">
 									<span class="label label-success" title="Published" 
@@ -321,10 +320,7 @@
 										{{ doc.displayName | removeExtension }}
 									</span>
 								</span>
-								<span class="col author-col" title="{{ doc.documentAuthor }}" hidden>
-									{{ doc.documentAuthor }}
-								</span>
-								<span class="col date-added-col">{{ doc.dateUploaded | date : format : timezone }}</span>
+								<span class="col date-col">{{ doc.documentDate | date : format : timezone }}</span>
 								<span class="col status-col last-col" 
 									ng-if="authentication.user">
 									<span class="label label-success" title="Published"
@@ -552,6 +548,14 @@
 									</span>
 								</li>
 								<li>
+									<span class="name">Name:</span>
+									<span class="value">{{ documentMgr.infoPanel.data.displayName | removeExtension }}</span>
+								</li>
+								<li ng-if="documentMgr.infoPanel.data.documentType">
+									<span class="name">Document Type:</span>
+									<span class="value">{{ documentTypes.display(documentMgr.infoPanel.data.documentType) }}</span>
+								</li>
+								<li>
 									<span class="name">Document Date:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.documentDate | date : format : timezone }}</span>
 								</li>
@@ -559,23 +563,17 @@
 									<span class="name">Uploaded Date:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.dateUploaded | date : format : timezone }}</span>
 								</li>
-								<li>
-									<span class="name">Link:</span>
-									<span class="value break-all">
-										<a href="{{documentMgr.infoPanel.data.link}}" target="_blank">{{ documentMgr.infoPanel.data.link }}</a>
-									</span>
+								<li ng-if="authentication.user">
+									<span class="name">File Name:</span>
+									<span class="value">{{ documentMgr.infoPanel.data.documentFileName }}</span>
 								</li>
 								<li>
-									<span class="name">Size:</span>
+									<span class="name">File Size:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.internalSize | bytes:2 }}</span>
 								</li>
 								<li>
-									<span class="name">Type:</span>
+									<span class="name">File Type:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.internalExt }}</span>
-								</li>
-								<li ng-if="documentMgr.infoPanel.data.documentType">
-									<span class="name">Document Type:</span>
-									<span class="value">{{ documentTypes.display(documentMgr.infoPanel.data.documentType) }}</span>
 								</li>
 								<li ng-if="documentMgr.infoPanel.data.documentType ==='Inspection Report' && documentMgr.infoPanel.data.inspectionReport">
 									<span class="name">Inspector Initials:</span>
@@ -585,9 +583,11 @@
 									<span class="name">Follow up:</span>
 									<span class="value">{{ documentMgr.infoPanel.data.inspectionReport.followup }}</span>
 								</li>
-								<li ng-if="authentication.user">
-									<span class="name">File Name:</span>
-									<span class="value">{{ documentMgr.infoPanel.data.documentFileName }}</span>
+								<li>
+									<span class="name">Link:</span>
+									<span class="value break-all">
+										<a href="{{documentMgr.infoPanel.data.link}}" target="_blank">{{ documentMgr.infoPanel.data.link }}</a>
+									</span>
 								</li>
 								<li ng-if="project.userCan.manageFolders && documentMgr.infoPanel.data.collections.length > 0">
 									<span class="name">Collection(s):</span>

--- a/modules/search/client/scss/search-results.scss
+++ b/modules/search/client/scss/search-results.scss
@@ -125,10 +125,6 @@ x-search-info-panel {
                         visibility: visible;
                     }
                 }
-
-                &.actions-col.x1 {
-                    width: 6.7rem;
-                }
             }
         }
     }
@@ -141,8 +137,7 @@ x-search-info-panel {
                 padding: 0;
                 vertical-align: top;
 
-                &.actions-col.x1 {
-                    width: 5rem;
+                &.actions-col {
                     text-align: initial;
 
                     .dropdown-menu {
@@ -238,19 +233,6 @@ x-search-info-panel {
             background-color: blue;
         }
     }
-
-    .date-added-col {
-        width: 11rem;
-    }
-
-    .status-col {
-        width: 10rem;
-
-        .glyphicon {
-            font-size: 1.8rem;
-            vertical-align: top;
-        }
-    }
 }
 
 @media (orientation: portrait)
@@ -276,26 +258,33 @@ and (max-device-width: 768px)  {
 @media (orientation: landscape)
 and (max-device-width: 1024px)  {
     .sr-table {
-        thead {
-            > tr {
-                > th {
-                    &.actions-col.x1 {
-                        width: 5rem;
-                    }
-                }
-            }
+        .actions-col {
+            width: 5rem;
+        }
+
+        .date-col{
+            width: 25%;
+        }
+
+        .status-col {
+            width: 20%;
         }
     }
 }
 
 @media (min-width: 1200px) {
     .sr-table {
-        .date-added-col {
-            width: 20rem;
+        thead {
+            padding-right: 17px;
         }
 
+        .actions-col {
+            width: 5rem;
+        }
+
+        .date-col,
         .status-col {
-            width: 12rem;
+            width: 20%;
         }
     }
 }

--- a/modules/search/client/views/search-info-panel.html
+++ b/modules/search/client/views/search-info-panel.html
@@ -28,8 +28,16 @@
 						<span class="name">Status:</span>
 						<span class="value">
 							<span class="label label-success" ng-if="vm.doc.isPublished">Published</span>
-							<span class="label label-default" ng-if="!vm.doc.isPublished">Not Published</span>
+							<span class="label label-unpublished" ng-if="!vm.doc.isPublished">Unpublished</span>
 						</span>
+					</li>
+					<li>
+						<span class="name">Name:</span>
+						<span class="value">{{ vm.doc.displayName | removeExtension }}</span>
+					</li>
+					<li ng-if="vm.doc.documentType">
+						<span class="name">Document Type:</span>
+						<span class="value">{{ vm.documentTypes.display(vm.doc.documentType) }}</span>
 					</li>
 					<li>
 						<span class="name">Document Date:</span>
@@ -39,17 +47,17 @@
 						<span class="name">Uploaded Date:</span>
 						<span class="value">{{ vm.doc.dateUploaded | date : format : timezone }}</span>
 					</li>
+					<li ng-if="vm.authentication.user">
+						<span class="name">File Name:</span>
+						<span class="value">{{ vm.doc.documentFileName }}</span>
+					</li>
 					<li>
-						<span class="name">Size:</span>
+						<span class="name">File Size:</span>
 						<span class="value">{{ vm.doc.internalSize | bytes:2 }}</span>
 					</li>
 					<li>
-						<span class="name">Type:</span>
+						<span class="name">File Type:</span>
 						<span class="value">{{ vm.doc.internalExt }}</span>
-					</li>
-					<li ng-if="vm.doc.documentType">
-						<span class="name">Document Type:</span>
-						<span class="value">{{ vm.documentTypes.display(vm.doc.documentType) }}</span>
 					</li>
 					<li ng-if="vm.doc.documentType ==='Inspection Report' && vm.doc.inspectionReport">
 						<span class="name">Inspector Initials:</span>

--- a/modules/search/client/views/search-results-documents.html
+++ b/modules/search/client/views/search-results-documents.html
@@ -26,7 +26,7 @@
 						<th class="name-col sortable" ng-class="vm.sorting.ascending" ng-click="vm.sortBy('name')">Name
 							<span class="sort-icon" ng-show="vm.sorting.column === 'name'"></span>
 						</th>
-						<th class="date-added-col sortable" ng-class="vm.sorting.ascending" ng-click="vm.sortBy('date')">Uploaded
+						<th class="date-col sortable" ng-class="vm.sorting.ascending" ng-click="vm.sortBy('date')">Document Date
 							<span class="sort-icon" ng-show="vm.sorting.column === 'date'"></span>
 						</th>
 						<th class="status-col sortable" ng-if="vm.authentication.user" ng-class="vm.sorting.ascending" ng-click="vm.sortBy('status')">Status
@@ -53,8 +53,8 @@
 											</div>
 										</div>
 									</td>
-									<td class="date-added-col">
-										{{ item.dateUploaded | date : format : timezone }}
+									<td class="date-col">
+										{{ item.doc.documentDate | date : format : timezone }}
 									</td>
 									<td class="status-col" ng-if="vm.authentication.user">
 										<span class="label label-success" ng-if="item.isPublished" title="Published">Published</span>


### PR DESCRIPTION
Changes the Upload Date column to Document Date

Additional Fixes
- Ensured consistent naming conventions and spacing through affected components (column widths)
- Removed a styling selector that was preventing columns from showing at smaller device widths
- Standardized some of the information displayed for the Document Info Window and Search Result Info Window
- Added explicit labels for 'File Name', and 'File Size' in both the Documents and Documents Search Results interfaces
- Fixed an issue with incorrect selector naming convention in the Search Info Panel interface
- Added additional selector to mixins