### PR TITLE
EM-321: Allow sysadmin to upload larger then 10mb filesize

### DIFF
--- a/modules/project-comments/client/directives/comment-directives.js
+++ b/modules/project-comments/client/directives/comment-directives.js
@@ -669,8 +669,8 @@ function PublicCommentPeriodModal($uibModal, CommentModel, Upload, $timeout, _, 
 
         $scope.project = scope.project;
 
-        var maxFileSize = 5 * 1024 * 1024; //5MB
-
+        var maxFileSize = 5 * 1024 * 1024; // 5MiB
+        s.isAdmin = scope.period.userCan.publish; // Admins may upload larger filesizes for business reasons
         s.step = 1;
         s.comment = comment;
         comment.period = scope.period;
@@ -688,7 +688,7 @@ function PublicCommentPeriodModal($uibModal, CommentModel, Upload, $timeout, _, 
             s.showAlert = false;
             s.comment.inProgress = false;
             _.each(newValue, function (file) {
-              if (file.size > maxFileSize) {
+              if (file.size > maxFileSize && !s.isAdmin) {
                 s.showAlert = true;
               } else if (!file.name.match(acceptedExtentions)){
                 s.showExtensionAlert = true;

--- a/modules/project-comments/client/views/public-comments/add.html
+++ b/modules/project-comments/client/views/public-comments/add.html
@@ -77,8 +77,8 @@
 					<!-- UPLOAD CONTAINER -->
 					<div class="fb-upload-container">
 						<div class="fb-upload-target-container">
-							<div class="fb-upload-target pcp" id="dropzone"
-								ngf-drop 
+              <div ng-class="{'fb-upload-target': true, 'pcp': !s.isAdmin}" id="dropzone"
+								ngf-drop
 								ngf-select
 								ngf-allow-dir="true"
 								ng-model="s.comment.files"
@@ -87,7 +87,7 @@
 								<div class="fb-upload-target-content">
 									<span class="glyphicon glyphicon-open icon-default"></span>
 									<span class="fb-upload-target-msg"><b>Drag &amp; Drop</b> or <b>browse files</b> to upload.</span>
-									<span class="fb-upload-req-msg">Size limited to 5MB.</span>
+									<span class="fb-upload-req-msg" ng-if="!s.isAdmin">Size limited to 5MB.</span>
 								</div>
 								<div class="fb-upload-target-border"></div>
 							</div>


### PR DESCRIPTION
- Created a flag to detect if the user is an admin (only admins can publish PCP's).
- If user is an admin, size limit is removed as well as the warning message in the dropzone.
- Also messed with the classes to ensure adequate spacing in the dropzone.