### PR TITLE
Enable autofix for eslint errors

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -25,7 +25,8 @@ module.exports = function(grunt) {
     eslint: {
       target: ['gruntfile.js', 'modules/**/*.js'],
       options: {
-        configFile: '.eslintrc'
+        configFile: '.eslintrc',
+        fix: true
       }
     },
     csslint: {


### PR DESCRIPTION
Enable eslint autofix for errors that can be addressed automatically (spacing, indentation, see [here](https://eslint.org/docs/rules/) for additional reference).