### PR TITLE
EM-836: Use native Promises to fix broken login in Angular 1.6+

### DIFF
--- a/modules/core/client/services/core.access.service.js
+++ b/modules/core/client/services/core.access.service.js
@@ -90,13 +90,14 @@ angular.module('core')
       reload: function (currentUser, force) {
         return new Promise(function (resolve, reject) {
           if ($window.application.user !== currentUser || force === true) {
-            $http.get('api/application').success(function (response) {
-              $window.application.userCan = response.userCan;
+            $http.get('api/application').then(function (response) {
+              $window.application.userCan = response.data.userCan;
               $window.application._id = 'application';
               $window.application.user = currentUser;
-              resolve(response.userCan);
-            })
-              .error(reject);
+              resolve(response.data.userCan);
+            }, function(){
+              reject();
+            });
           }
           else {
             resolve();

--- a/modules/users/client/controllers/authentication.client.controller.js
+++ b/modules/users/client/controllers/authentication.client.controller.js
@@ -32,13 +32,13 @@ function controllerAuthentication($scope, $state, $http, $location, $window, Aut
       return false;
     }
 
-    $http.post('/api/auth/signup', loginPanel.credentials).success(function (response) {
+    $http.post('/api/auth/signup', loginPanel.credentials).then(function (response) {
       // If successful we assign the response to the global user model
-      loginPanel.authentication.user = response;
+      loginPanel.authentication.user = response.data;
       // And redirect to the previous or home page
       $state.go($state.previous.state.name || 'projects', $state.previous.params);
-    }).error(function (response) {
-      loginPanel.error = response.message;
+    }, function (response) {
+      loginPanel.error = response.data.message;
     });
   };
 
@@ -49,13 +49,13 @@ function controllerAuthentication($scope, $state, $http, $location, $window, Aut
 
       return false;
     }
-    $http.post('/api/auth/signin', loginPanel.credentials).success(function (response) {
+    $http.post('/api/auth/signin', loginPanel.credentials).then(function (response) {
       // If successful we assign the response to the global user model
-      loginPanel.authentication.user = response;
+      loginPanel.authentication.user = response.data;
       // And redirect to the previous or home page
       $state.go('projects');
-    }).error(function (response) {
-      loginPanel.error = response.message;
+    }, function (response) {
+      loginPanel.error = response.data.message;
     });
   };
 

--- a/modules/users/client/controllers/password.client.controller.js
+++ b/modules/users/client/controllers/password.client.controller.js
@@ -13,15 +13,15 @@ angular.module('users').controller('PasswordController', ['$scope', '$stateParam
     $scope.askForPasswordReset = function () {
       $scope.success = $scope.error = null;
 
-      $http.post('/api/auth/forgot', $scope.credentials).success(function (response) {
+      $http.post('/api/auth/forgot', $scope.credentials).then(function (response) {
         // Show user success message and clear form
         $scope.credentials = null;
-        $scope.success = response.message;
+        $scope.success = response.data.message;
 
-      }).error(function (response) {
+      }, function (response) {
         // Show user error message and clear form
         $scope.credentials = null;
-        $scope.error = response.message;
+        $scope.error = response.data.message;
       });
     };
 
@@ -29,17 +29,17 @@ angular.module('users').controller('PasswordController', ['$scope', '$stateParam
     $scope.resetUserPassword = function () {
       $scope.success = $scope.error = null;
 
-      $http.post('/api/auth/reset/' + $stateParams.token, $scope.passwordDetails).success(function (response) {
+      $http.post('/api/auth/reset/' + $stateParams.token, $scope.passwordDetails).then(function (response) {
         // If successful show success message and clear form
         $scope.passwordDetails = null;
 
         // Attach user profile
-        Authentication.user = response;
+        Authentication.user = response.data;
 
         // And redirect to the index page
         $location.path('/password/reset/success');
-      }).error(function (response) {
-        $scope.error = response.message;
+      }, function (response) {
+        $scope.error = response.data.message;
       });
     };
   }

--- a/modules/users/client/controllers/settings/change-password.client.controller.js
+++ b/modules/users/client/controllers/settings/change-password.client.controller.js
@@ -14,13 +14,13 @@ angular.module('users').controller('ChangePasswordController', ['$scope', '$http
         return false;
       }
 
-      $http.post('/api/users/password', $scope.passwordDetails).success(function (/* response */) {
+      $http.post('/api/users/password', $scope.passwordDetails).then(function (/* response */) {
         // If successful show success message and clear form
         $scope.$broadcast('show-errors-reset', 'passwordForm');
         $scope.success = true;
         $scope.passwordDetails = null;
-      }).error(function (response) {
-        $scope.error = response.message;
+      }, function (response) {
+        $scope.error = response.data.message;
       });
     };
   }

--- a/modules/users/client/controllers/settings/manage-social-accounts.client.controller.js
+++ b/modules/users/client/controllers/settings/manage-social-accounts.client.controller.js
@@ -26,12 +26,12 @@ angular.module('users').controller('SocialAccountsController', ['$scope', '$http
         params: {
           provider: provider
         }
-      }).success(function (response) {
+      }).then(function (response) {
         // If successful show success message and clear form
         $scope.success = true;
-        $scope.user = Authentication.user = response;
-      }).error(function (response) {
-        $scope.error = response.message;
+        $scope.user = Authentication.user = response.data;
+      }, function (response) {
+        $scope.error = response.data.message;
       });
     };
   }


### PR DESCRIPTION
Angular 1.6 deprecated the _success_/_error_ promise functions in favor of using the native _then_.

The calls to _success_ and _error_ have been replaced and, as a consequence of this, the *response* object now requires the data to be explicitly extracted from it.

See [here](https://stackoverflow.com/questions/35329384/why-are-angular-http-success-error-methods-deprecated-removed-from-v1-6) for some backround information.