### PR TITLE
EM-1096: Update api to remove proponent response as needed. Update ap…

### DIFF
--- a/modules/project-comments/server/controllers/comment.controller.js
+++ b/modules/project-comments/server/controllers/comment.controller.js
@@ -178,14 +178,22 @@ module.exports = DBModel.extend ({
         .then (resolve, reject);
     });
   },
-  getPublishedCommentsForPeriod : function (periodId) {
+  getPublishedCommentsForPeriod: function (periodId) {
     var self = this;
-    return new Promise (function (resolve, reject) {
-      self.findMany ({
-        period : periodId,
+    return new Promise(function (resolve, reject) {
+      self.findMany({
+        period: periodId,
         isPublished: true
-      })
-        .then (resolve, reject);
+      }).then(function (data) {
+        return data.map(function (record) {
+          if (record.showProponentResponse !== true) {
+            //TODO in mongo>3.6 removing fields can be done using a combination of $project, $cond and $$REMOVE
+            record.showProponentResponse = null;
+            record.proponentResponse = null;
+          }
+          return record;
+        });
+      }).then(resolve, reject);
     });
   },
   getAllCommentsForPeriod : function (periodId) {

--- a/modules/project-comments/server/routes/comment.routes.js
+++ b/modules/project-comments/server/routes/comment.routes.js
@@ -58,7 +58,7 @@ module.exports = function (app) {
     .get (routes.setAndRun (CommentModel, function (model, req) {
       return model.getCommentsForTarget (req.params.targettype, req.params.targetid, req.params.type);
     }));
-  app.route ('/api/comments/period/:periodId/all').all(policy ('guest'))
+  app.route ('/api/comments/period/:periodId/all').all(policy ('user'))
     .get (routes.setAndRun (CommentModel, function (model, req) {
       return model.getAllCommentsForPeriod (req.params.periodId);
     }));
@@ -75,7 +75,7 @@ module.exports = function (app) {
       return model.getProponentCommentsForPeriod (req.params.periodId);
     }));
 
-  app.route ('/api/comments/period/:periodId/paginate').all(policy ('guest'))
+  app.route ('/api/comments/period/:periodId/paginate').all(policy ('user'))
     .put (routes.setAndRun (CommentModel, function (model, req) {
       return model.getPeriodPaginate(req.body);
     }));


### PR DESCRIPTION
…i permissions to only return published comments

Changed the policy level on a few apis to support logged in users only.
Updated the front end call to use the published comments api endpoint, as before it was getting unpublished comments as well, and then filtering them, which isnt good.
