### PR TITLE
EM-1099: Undoing css change not needed

### DIFF
--- a/modules/core/client/scss/components/map.scss
+++ b/modules/core/client/scss/components/map.scss
@@ -9,11 +9,6 @@
 		font-weight: bold;
 	}
 
-	.map-mouseover-hidden-description-content {
-		display: none;
-		visibility: hidden;
-	}
-
 	.map-popup-content,
 	.map-popup-type,
 	.map-popup-links {


### PR DESCRIPTION
This went in to the wrong place and is obsolete because we refactored it out anyways.