### PR TITLE
Pending and Closed comment banners EM-1251, EM-1252

### DIFF
--- a/modules/project-comments/client/scss/project-comments.scss
+++ b/modules/project-comments/client/scss/project-comments.scss
@@ -266,6 +266,7 @@ $pcp-comment-icon-color: #ccc;
       @include flex(1 1 auto);
       padding: 1rem;
       border: $pcp-btn-border;
+      margin: 1rem;
       border-radius: 0.25rem;
       background-color: $pcp-btn-bg;
       color: $pcp-btn-color;

--- a/modules/project-comments/client/views/period-list.html
+++ b/modules/project-comments/client/views/period-list.html
@@ -6,21 +6,19 @@
 </div>
 
 <div class="view-body-container">
-
   <!-- PUBLIC COMMENT PERIOD IF ACTIVE -->
   <div class="pcp-banner" ng-if="activeperiod">
     <section class="pcp-info">
-      <h2>Public Comment Period <span class="break">is Now Open</span></h2>
+      <h2>Public Comment Period <span class="break">is Currently <strong>{{activeperiod.periodStatus}}</strong></span></h2>
       <span class="pcp-dates"><strong>{{ activeperiod.dateStarted | amDateFormat:'MMMM Do, YYYY' }}</strong> &nbsp;-&nbsp; <strong>{{ activeperiod.dateCompleted | amDateFormat:'MMMM Do, YYYY' }}</strong></span>
       <span class="pcp-desc">
         This Public Comment Period is regarding the <strong>{{activeperiod.informationLabel}}</strong><span ng-if="activeperiod.ceaaInformationLabel"> and the <strong>{{activeperiod.ceaaInformationLabel}}</strong></span>.
       </span>
       <div class="pcp-banner-btns">
-        <a class="btn btn-primary" title="View Details" ui-sref="p.commentperiod.detail({periodId:activeperiod._id})">
+        <a class="btn btn-primary" title="View Details" ui-sref="p.commentperiod.detail({periodId:activeperiod._id})" ng-if="authentication.user">
           <span class="glyphicon glyphicon-th-list"></span><span>View Comments</span>
         </a>
-        <span class="spacer">OR</span>
-        <button class="btn btn-primary" ng-if="allowCommentSubmit" x-add-public-comment x-project="project" x-period="activeperiod">
+        <button class="btn btn-primary" ng-if="(allowCommentSubmit && authentication.user) || (activeperiod.periodStatus == 'Open')" x-add-public-comment x-project="project" x-period="activeperiod">
           <span class="glyphicon glyphicon-comment"></span><span>Submit a Comment</span>
         </button>
       </div>
@@ -59,12 +57,12 @@
           <span class="count">{{p.stats.totalPublic}}</span>
         </td>
         <td class="actions-col" header-class="'actions-col x1'" ng-if="project.userCan.createCommentPeriod">
-          
+
           <div class="btn-group">
-            <button class="btn icon-btn dropdown-toggle" 
+            <button class="btn icon-btn dropdown-toggle"
               popover-class="context-menu"
               popover-placement="bottom-right auto"
-              popover-trigger="'focus'" 
+              popover-trigger="'focus'"
               uib-popover-template="'pcp-list-menu.html'">
               <span class="glyphicon glyphicon glyphicon-option-vertical"></span>
             </button>

--- a/modules/projects/client/views/project-partials/project.detail.html
+++ b/modules/projects/client/views/project-partials/project.detail.html
@@ -40,7 +40,7 @@
 				</button>
 			</div>
 		</section>
-	</div>
+  </div>
 
 	<!-- PROJECT TIMELINE -->
 	<section class="panel panel-default">


### PR DESCRIPTION
EM-1251: Creating a banner that changes based on 'Open', 'Closed', an…d 'Pending' states for the period. Outside period banner on both sides will display for 7 days.

EM-1251: refactoring in progress to make code more modular

EM-1251: made pending, active, and ending banners to fit within current banner structure. TODO: Decide and if so make it so comments can be added after term only by staff.

EM-1251: added functionality for submit button appearing only for admin after period closes. Removed 'or' between buttons

EM-1251: Cleanup

EM-1251: Cleanup 1.1

EM-1251: cleanup 1.2