### PR TITLE
Removed unnecessary console, handle temp file removal on failed upload.

### DIFF
--- a/modules/documents/server/routes/core.document.routes.js
+++ b/modules/documents/server/routes/core.document.routes.js
@@ -127,7 +127,6 @@ module.exports = function (app) {
         if (req.file) {
           return MinioController.putDocument(MinioController.BUCKETS.DOCUMENTS_BUCKET, req.Project.code, req.file.originalname, req.file.path)
             .then(function(minioFile){
-              console.log("AIO!", minioFile); //eslint-disable-line
               return new Promise (function (resolve, reject) {
                 var modelData = {
                   // Metadata related to this specific document that has been uploaded.
@@ -175,6 +174,9 @@ module.exports = function (app) {
               })
             })
             .catch(function(error) {
+              // remove file from temp folder
+              fs.unlink(req.file.path);
+
               // general catch all
               return Promise.reject(error);
             });


### PR DESCRIPTION
I added the temp file removal to the catch clause of the running promise, so that the tempfile will be removed if the upload to Minio fails