### PR TITLE
EM-1307: Comment period custom setting: can set same day problem

### DIFF
--- a/modules/utils/client/directives/utils.client.directives.js
+++ b/modules/utils/client/directives/utils.client.directives.js
@@ -854,12 +854,24 @@ function directiveModalDatePicker($uibModal, $rootScope, $timeout) {
               return !scope.hideTime;
             },
             mindate: function () {
-              //start date selected in editPCP page datepicker
-              return scope.min;
+              //start date selected in editPCP page datepicker. Follows day zero rules
+              if (scope.min!=null) {
+                var dayZero = new Date(scope.min);
+                dayZero.setDate(dayZero.getDate() + 1);
+                return dayZero;
+              } else {
+                return scope.min;
+              }
             },
             maxdate: function () {
-              //end date selected in editPCP page datepicker
-              return scope.max;
+              //end date selected in editPCP page datepicker. Follows day zero rules
+              if (scope.max!=null) {
+                var dayZero = new Date(scope.max);
+                dayZero.setDate(dayZero.getDate() - 1);
+                return dayZero;
+              } else {
+                return scope.max;
+              }
             },
             isend: function (){
               //modal is for start or completed date


### PR DESCRIPTION
EM-1307:
Calendar previously allowed for same day setting for start and end date as long as it followed time rules.
Changes modify the allowed days by one on each side to fit day zero rules.
i.e. Public comment period starts the day after being set. As a result pcp cannot start/end on the same day.