### PR TITLE
EM-1304: Create new Public Comment Period Banners for EPIC "Public" project landing pages

### DIFF
--- a/modules/recent-activity/server/routes/recent-activity.routes.js
+++ b/modules/recent-activity/server/routes/recent-activity.routes.js
@@ -17,7 +17,7 @@ module.exports = function (app) {
   // all active activities
   //
   app.route('/api/recentactivity/getPublishedCommentPeriodsForProject/:projectId')
-    .all(policy('user'))
+    .all(policy('guest'))
     .get(routes.setAndRun(RecentActivity, function (model, req) {
       return model.getPublishedCommentPeriodsForProject(req.params.projectId);
     }));


### PR DESCRIPTION
changed policy on api call for published pcps for a project from a logged in user to public. Needed to implement public banner functionality on eao-public. This is tied to EM-1304 work in eao-public repo.