### PR TITLE
EM-1424: Can't Delete an Unpublished, Unstarted PCP

### DIFF
--- a/modules/project-comments/client/views/period-list.html
+++ b/modules/project-comments/client/views/period-list.html
@@ -86,7 +86,7 @@
                     <span class="glyphicon glyphicon-ok-circle"></span>Publish
                 </a>
                 </li>
-                <li ng-if="p.isPublished && project.userCan.createCommentPeriod">
+                <li ng-if="p.isPublished && project.userCan.createCommentPeriod && p.openState.state === 'Pending'">
                   <a title="Unpublish Comment"
                     ng-click="$event.stopPropagation();"
                     ng-disabled="p.openForComment"
@@ -113,7 +113,7 @@
                     <span class="glyphicon glyphicon-trash"></span>Delete
                   </a>
                 </li>
-                <li ng-if="project.userCan.createCommentPeriod && !p.openForComment && p.openState.state === 'Pending'">
+                <li ng-if="project.userCan.createCommentPeriod && !p.openForComment && p.openState.state !== 'Completed'">
                   <a title="Delete Comment Period"
                     ng-click="$event.stopPropagation();"
                     x-confirm-dialog


### PR DESCRIPTION
EM-1424: fixed the bug that disabled deleting unpublished pcps. Current logic is: Unpublished pcps can be published or deleted. Pending can be unpublished or deleted. Open or closed cannot be deleted or unpublished.