### PR TITLE
EM-257: Fixed ellipsis in edge

### DIFF
--- a/modules/project-comments/client/views/period-list.html
+++ b/modules/project-comments/client/views/period-list.html
@@ -58,7 +58,7 @@
         </td>
         <td class="actions-col" header-class="'actions-col x1'" ng-if="project.userCan.createCommentPeriod">
 
-          <div class="btn-group">
+          <div class="btn-group" ng-click="$event.stopPropagation();">
             <button class="btn icon-btn dropdown-toggle"
               popover-class="context-menu"
               popover-placement="bottom-right auto"
@@ -139,4 +139,3 @@
     </table>
   </div>
 </div>
-


### PR DESCRIPTION
The click event on the ellipsis button was propagating up to the pcp table row and opening the pcp page. This was a problem in Firefox and IE as well.