### PR TITLE
EM-302 Fix missing file extensions on download

### DIFF
--- a/modules/documents/server/routes/core.document.routes.js
+++ b/modules/documents/server/routes/core.document.routes.js
@@ -112,6 +112,10 @@ module.exports = function (app) {
         return res.redirect(req.Document.internalURL);
       } else {
         var fileName = req.Document.documentFileName;
+        var fileType = req.Document.internalExt;
+        if (fileName.slice(- fileType.length) !== fileType){
+          fileName = fileName + '.' + fileType;
+        }
         var fileMeta;
 
         // check if the file exists in Minio


### PR DESCRIPTION
Append file extension at download time based on the `internalExt` field which seems to stay intact in the database, even when the filename loses its extension. 